### PR TITLE
Fix permissions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo systemctl restart nginx
 6. (Only if accepting Cashu tokens) Provide permission to the Nginx user to access the Cashu database:
 ```bash
 sudo chown nginx:nginx /var/lib/nginx/cashu_wallet.db
-sudo chmod 666 /var/lib/nginx/cashu_wallet.db
+sudo chmod 660 /var/lib/nginx/cashu_wallet.db
 ```
 
 ## Building from Source


### PR DESCRIPTION
Hello, we were just looking at your project because of [Austin LitDevs](https://austinlitdevs.com/2025-05-12-litdevs-18) and I noticed that you're using `chmod 666`. This gives read and write permissions to anyone:

```
$ touch test
$ chmod 666 test
$ ls -l test
-rw-rw-rw- 1 ekzyis users 0 May 12 20:09 test
```

I think you meant to use `chmod 660`, which only gives read and write permissions to the user and group:

```
$ chmod 660 test
$ ls -l test
-rw-rw---- 1 ekzyis users 0 May 12 20:09 test
```