### PR TITLE
 improve Cargo cache configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
+      - name: Cache Cargo registry + build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-export-modules-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes: https://github.com/DhananjayPurohit/ngx_l402/issues/38

Reduces the runtime for building cargo modules from `~8 minutes` to `~20 seconds` via introducing cache. Cache is based on `cargo.lock` for builds that do not have any changes in the dependencies

Overall, the run time reduced from ~14 minutes to ~6 minutes

<img width="1288" height="415" alt="image" src="https://github.com/user-attachments/assets/9cfbd8f6-5fad-455f-91de-c91373c0cf40" />
