### PR TITLE
correct volume mapping for lndnode in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - "10009:10009"
       - "8080:8080"
     volumes:
-      - lndnode-data:/data/.lnd:rw
+      - lndnode-data:/data:rw
       - lndnode-data:/root/.lnd:rw
     restart: unless-stopped
     environment:


### PR DESCRIPTION
fixes: #43 

Fixes the wallet initialisation issue in `lndnode` when the container is restarted.

Earlier, the lnd node container failed to start as the volume mapping failed to persist the secrets leading to crash