### PR TITLE
docs: update mermaid diagram and remove obsolete experimental flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ An [L402](https://docs.lightning.engineering/the-lightning-network/l402) authent
 graph TD;
     A[Request Received] --> B{Endpoint L402 Enabled?}
     B -->|No| C[Return 200 OK]
-    B -->|Yes| D{Authorization Header present in request?}
+    B -->|Yes| D{"Any auth header present? (L402 or X-Cashu)"}
     D -->|No| F[Generate L402 Header macaroon & invoice]
     F --> G{Header Generation Success?}
     G -->|Yes| H[Add WWW-Authenticate Header]
     G -->|No| I[Return 500 Internal Server Error]
     H --> J[Return 402 Payment Required]
-    D -->|Yes| K[Parse L402 Header macaroon & preimage]
+    D -->|Yes| K["Parse L402 macaroon/preimage or X-Cashu (if present)"]
     K --> L{Parse Success?}
     L -->|No| M[Return 500 Internal Server Error]
-    L -->|Yes| N[Verify L402]
+    L -->|Yes| N["Verify macaroon/preimage OR Cashu proofs (whitelist; P2PK lock if enabled; double-spend check; amount >= price)"]
     N --> O{Verification Success?}
     O -->|Yes| P[Return 200 OK]
     O -->|No| Q[Return 401 Unauthorized]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
           --grpc-port=9996 \
           --plugin=/usr/local/libexec/c-lightning/plugins/cln-nip47 \
           --nip47-relays=wss://relay.damus.io \
-          --experimental-offers \
           --rpc-file-mode=0666
     ports:
       - "9835:9835"


### PR DESCRIPTION
- Update mermaid diagram to reflect X-Cashu authentication support
- Add detailed Cashu proof verification steps in flow diagram
- Remove obsolete --experimental-offers flag from CLN v25.05 config