### PR TITLE
feat: dynamic mint parameter discovery (NUT-05, NUT-08)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1371,51 +1371,42 @@ jobs:
           echo "════════════════════════════════════════════════════"
           echo ""
           
-          echo "[1/3] Checking if feature was triggered during redemption..."
+          # Redemption logs are written to a dedicated file, not stdout
+          REDEMPTION_LOG="/var/log/nginx/cashu_redemption.log"
           
-          # Check logs for the feature trigger
-          if docker logs nginx-lnd 2>&1 | grep -q "Fetching Mint Info for dynamic parameter discovery"; then
-            echo "✅ Dynamic parameter discovery feature triggered successfully"
+          echo "[1/3] Checking redemption log file..."
+          if docker exec nginx-lnd test -f "$REDEMPTION_LOG"; then
+            echo "✅ Redemption log file exists"
             echo ""
             
-            echo "[2/3] Extracting discovery results from logs..."
-            docker logs nginx-lnd 2>&1 | grep -E "(Fetching Mint Info|Found dynamic|Using default)" | tail -15
-            echo ""
-            
-            echo "[3/3] Verifying discovery outcomes..."
-            
-            # Check NUT-05 (melt limits)
-            if docker logs nginx-lnd 2>&1 | grep -q "Found dynamic melt minimum:"; then
-              MELT_MIN=$(docker logs nginx-lnd 2>&1 | grep "Found dynamic melt minimum:" | tail -1)
-              echo "✅ NUT-05: $MELT_MIN"
-            else
-              echo "ℹ️  NUT-05: Using default minimum (mint didn't provide)"
-            fi
-            
-            # Check NUT-08 (fees)
-            if docker logs nginx-lnd 2>&1 | grep -q "Found dynamic fee:.*ppk"; then
-              FEE_LINE=$(docker logs nginx-lnd 2>&1 | grep "Found dynamic fee:.*ppk" | tail -1)
-              echo "✅ NUT-08: $FEE_LINE"
+            echo "[2/3] Checking if dynamic parameter discovery triggered..."
+            if docker exec nginx-lnd grep -q "Fetching Mint Info for dynamic parameter discovery" "$REDEMPTION_LOG"; then
+              echo "✅ Dynamic parameter discovery feature triggered"
+              echo ""
               
-              if docker logs nginx-lnd 2>&1 | grep -q "Found dynamic min fee:"; then
-                MIN_FEE_LINE=$(docker logs nginx-lnd 2>&1 | grep "Found dynamic min fee:" | tail -1)
-                echo "✅ NUT-08: $MIN_FEE_LINE"
-              fi
+              echo "[3/3] Extracting discovery results..."
+              docker exec nginx-lnd grep -E "(Fetching Mint Info|Found dynamic|NUT-05|NUT-08|Using default)" "$REDEMPTION_LOG" | tail -10
+              echo ""
+              echo "════════════════════════════════════════════════════"
+              echo "   ✅ Dynamic Parameter Discovery Test PASSED"
+              echo "════════════════════════════════════════════════════"
             else
-              echo "ℹ️  NUT-08: Using default fees (mint didn't provide)"
+              echo "❌ FAILED: Dynamic parameter discovery did NOT trigger"
+              echo ""
+              echo "Redemption log contents:"
+              docker exec nginx-lnd cat "$REDEMPTION_LOG"
+              echo ""
+              echo "════════════════════════════════════════════════════"
+              echo "   ❌ Dynamic Parameter Discovery Test FAILED"
+              echo "════════════════════════════════════════════════════"
+              exit 1
             fi
-            
-            echo ""
-            echo "════════════════════════════════════════════════════"
-            echo "   ✅ Dynamic Parameter Discovery Test PASSED"
-            echo "════════════════════════════════════════════════════"
           else
-            echo "❌ FAILED: Dynamic parameter discovery feature did NOT trigger"
+            echo "❌ FAILED: Redemption log file not found"
+            echo "Expected: $REDEMPTION_LOG"
             echo ""
-            echo "Expected to find log message: 'Fetching Mint Info for dynamic parameter discovery'"
-            echo ""
-            echo "Recent nginx-lnd logs (last 100 lines):"
-            docker logs nginx-lnd 2>&1 | tail -100
+            echo "Checking nginx-lnd container logs:"
+            docker logs nginx-lnd 2>&1 | tail -50
             echo ""
             echo "════════════════════════════════════════════════════"
             echo "   ❌ Dynamic Parameter Discovery Test FAILED"

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -880,6 +880,9 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
 
         // Fetch Mint Info for dynamic parameter discovery
         info!("Fetching Mint Info for dynamic parameter discovery...");
+        cashu_redemption_logger::log_redemption(
+            "Fetching Mint Info for dynamic parameter discovery...",
+        );
         match wallet_clone.fetch_mint_info().await {
             Ok(mint_info) => {
                 debug!("Mint Info fetched");
@@ -923,6 +926,10 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
                                                     "Found dynamic melt minimum: {} {}",
                                                     min_amount, unit
                                                 );
+                                                cashu_redemption_logger::log_redemption(&format!(
+                                                    "Found dynamic melt minimum: {} {}",
+                                                    min_amount, unit
+                                                ));
                                             }
                                             // Note: max_amount could be used to inform batching, but we'll keep current behavior for now
                                         }
@@ -955,6 +962,10 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
                                                 "Found dynamic fee: {} ppk -> {}%",
                                                 ppk, current_fee_reserve_percent
                                             );
+                                            cashu_redemption_logger::log_redemption(&format!(
+                                                "Found dynamic fee: {} ppk -> {}%",
+                                                ppk, current_fee_reserve_percent
+                                            ));
                                             found = true;
                                         }
 
@@ -967,6 +978,10 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
                                                 min_fee
                                             };
                                             info!("Found dynamic min fee: {} {}", min_fee, unit);
+                                            cashu_redemption_logger::log_redemption(&format!(
+                                                "Found dynamic min fee: {} {}",
+                                                min_fee, unit
+                                            ));
                                         }
                                     }
                                 }
@@ -989,6 +1004,10 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
                     "Failed to fetch Mint Info: {}. Using default parameters.",
                     e
                 );
+                cashu_redemption_logger::log_redemption(&format!(
+                    "Failed to fetch Mint Info: {}. Using default parameters.",
+                    e
+                ));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use env_logger;
+use hex;
 use l402_middleware::middleware::L402Middleware;
 use l402_middleware::{bolt12, cln, l402, lnclient, lnd, lnurl, macaroon_util, nwc, utils};
 use log::{debug, error, info, warn};
@@ -14,8 +15,7 @@ use ngx::http::{ngx_http_conf_get_module_main_conf, HTTPModule, Merge, MergeConf
 use ngx::{ngx_log_error, ngx_null_command, ngx_string};
 use redis::Client as RedisClient;
 use redis::Commands;
-use sha2::{Sha256, Digest};
-use hex;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::ffi::c_char;
 use std::ffi::CStr;
@@ -133,9 +133,7 @@ fn is_preimage_used(preimage: &[u8]) -> bool {
 /// Store a preimage as used with TTL (default 24 hours)
 /// This prevents replay attacks by marking preimages as consumed
 fn store_preimage_as_used(preimage: &[u8]) -> Result<(), String> {
-    let redis_client = REDIS_CLIENT
-        .get()
-        .ok_or("Redis not configured")?;
+    let redis_client = REDIS_CLIENT.get().ok_or("Redis not configured")?;
 
     let mut client_guard = redis_client
         .lock()
@@ -161,7 +159,10 @@ fn store_preimage_as_used(preimage: &[u8]) -> Result<(), String> {
     conn.set_ex::<_, _, ()>(&redis_key, "used", ttl_seconds)
         .map_err(|e| format!("Failed to store preimage in Redis: {}", e))?;
 
-    info!("✅ Stored preimage as used: {} (TTL: {}s)", preimage_hash, ttl_seconds);
+    info!(
+        "✅ Stored preimage as used: {} (TTL: {}s)",
+        preimage_hash, ttl_seconds
+    );
     Ok(())
 }
 
@@ -194,7 +195,10 @@ pub fn is_cashu_token_used(token: &str) -> bool {
     match conn.exists::<_, bool>(&redis_key) {
         Ok(exists) => {
             if exists {
-                warn!("⚠️ Cashu token replay attack detected: {}", &token_hash[..16]);
+                warn!(
+                    "⚠️ Cashu token replay attack detected: {}",
+                    &token_hash[..16]
+                );
             }
             exists
         }
@@ -208,9 +212,7 @@ pub fn is_cashu_token_used(token: &str) -> bool {
 /// Store a Cashu token as used with TTL (default 24 hours)
 /// This prevents replay attacks by marking tokens as consumed
 pub fn store_cashu_token_as_used(token: &str) -> Result<(), String> {
-    let redis_client = REDIS_CLIENT
-        .get()
-        .ok_or("Redis not configured")?;
+    let redis_client = REDIS_CLIENT.get().ok_or("Redis not configured")?;
 
     let mut client_guard = redis_client
         .lock()
@@ -236,7 +238,11 @@ pub fn store_cashu_token_as_used(token: &str) -> Result<(), String> {
     conn.set_ex::<_, _, ()>(&redis_key, "used", ttl_seconds)
         .map_err(|e| format!("Failed to store Cashu token in Redis: {}", e))?;
 
-    info!("✅ Stored Cashu token as used: {} (TTL: {}s)", &token_hash[..16], ttl_seconds);
+    info!(
+        "✅ Stored Cashu token as used: {} (TTL: {}s)",
+        &token_hash[..16],
+        ttl_seconds
+    );
     Ok(())
 }
 
@@ -1024,13 +1030,13 @@ pub fn l402_access_handler(
                     ) {
                         Ok(_) => {
                             info!("✅ L402 verification successful");
-                            
+
                             // Store preimage as used to prevent replay attacks
                             if let Err(e) = store_preimage_as_used(&preimage.0) {
                                 error!("⚠️ Failed to store preimage in Redis: {}", e);
                                 // Continue anyway - verification was successful
                             }
-                            
+
                             return NGX_DECLINED.try_into().unwrap();
                         }
                         Err(e) => {


### PR DESCRIPTION
## What
Auto-discovers melt parameters from mint's `/v1/info` endpoint (NUT-05, NUT-08) instead of using hardcoded env vars.

## Why
Each mint has different minimum amounts and fee structures. Previously these had to be manually configured via env vars, causing redemption failures when misconfigured. This queries the mint directly and falls back to conservative defaults if unavailable.

## How
- Calls `wallet.fetch_mint_info()` during redemption
- **NUT-05**: Discovers `min_amount` (replaces `CASHU_MELT_MIN_BALANCE_SATS`)
- **NUT-08**: Discovers `ppk` and `min` fee (replaces `CASHU_MELT_FEE_RESERVE_PERCENT`, `CASHU_MELT_MIN_FEE_RESERVE_SATS`)
- Falls back to env vars or hardcoded defaults if mint doesn't provide
- Adapts to cdk 0.14.1 API change (`get_mint_info()` → `fetch_mint_info()`)
- Adds CI test for verification

Example `/v1/info` response:
```json
{
  "nuts": {
    "5": {
      "methods": [{
        "method": "bolt11",
        "unit": "sat",
        "min_amount": 100,
        "max_amount": 10000
      }]
    },
    "8": [{
      "method": "bolt11",
      "unit": "sat",
      "ppk": 10,    // 1% fee
      "min": 1000   // 1000 sats minimum
    }]
  }
}
```

## Testing
- [x] CI test verifies NUT-05 and NUT-08 discovery from logs
- [x] Existing integration tests cover redemption flow
- [x] Backward compatible (env vars still work)

## Checklist
- [x] Code formatted with `cargo fmt`
- [x] Commit messages follow conventional commits
- [x] No breaking changes to existing deployments
- [x] Environment variables work as fallback (backward compatible)

Closes #52
