### PR TITLE
feat: dry run mode for safe production rollout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,6 +176,85 @@ jobs:
 
           echo "✅ Multi-tenant LNURL Lightning integration tests completed!"
 
+      - name: Run Integration Tests - Dry-Run (Shadow) Mode & Metrics
+        run: |
+          echo "Testing l402_dry_run shadow mode and l402_metrics endpoint..."
+
+          # Shadow mode must always pass through — same request that returns
+          # 402 on /protected must return 200 on /shadow.
+          echo "Request to /shadow without Authorization (expect 200, no 402)..."
+          shadow_resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/shadow)
+          shadow_code=$(echo "$shadow_resp" | tail -n1)
+          if [ "$shadow_code" -ne 200 ]; then
+            echo "FAIL: /shadow returned $shadow_code, expected 200 (dry-run must not block)"
+            echo "$shadow_resp"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /shadow returned 200"
+
+          if ! echo "$shadow_resp" | grep -qi "^X-L402-Dry-Run: 1"; then
+            echo "FAIL: X-L402-Dry-Run header missing from /shadow response"
+            echo "$shadow_resp"
+            exit 1
+          fi
+          echo "PASS: X-L402-Dry-Run: 1 header present"
+
+          if ! echo "$shadow_resp" | grep -qi "^X-L402-Dry-Run-Price-Msat: 10000"; then
+            echo "FAIL: X-L402-Dry-Run-Price-Msat header missing/incorrect"
+            echo "$shadow_resp"
+            exit 1
+          fi
+          echo "PASS: X-L402-Dry-Run-Price-Msat: 10000 present"
+
+          # Challenge synthesis may legitimately fail if the LN backend is
+          # flaky — we count it but don't fail the request. Just log whether
+          # a challenge header came back for visibility.
+          if echo "$shadow_resp" | grep -qi "^X-L402-Dry-Run-Challenge:"; then
+            echo "INFO: X-L402-Dry-Run-Challenge header present (LN backend reachable)"
+          else
+            echo "INFO: X-L402-Dry-Run-Challenge absent (LN backend may be unreachable — non-fatal)"
+          fi
+
+          # Metrics endpoint — must serve text/plain Prometheus exposition.
+          echo "Scraping /metrics endpoint..."
+          metrics_resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/metrics)
+          metrics_code=$(echo "$metrics_resp" | tail -n1)
+          if [ "$metrics_code" -ne 200 ]; then
+            echo "FAIL: /metrics returned $metrics_code, expected 200"
+            echo "$metrics_resp"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /metrics returned 200"
+
+          if ! echo "$metrics_resp" | grep -qi "^Content-Type: text/plain"; then
+            echo "FAIL: /metrics Content-Type is not text/plain"
+            echo "$metrics_resp"
+            exit 1
+          fi
+          echo "PASS: Content-Type is text/plain"
+
+          for counter in l402_requests_total l402_dry_run_requests_total l402_dry_run_would_block_total; do
+            if ! echo "$metrics_resp" | grep -q "^${counter} "; then
+              echo "FAIL: expected counter ${counter} missing from /metrics body"
+              echo "$metrics_resp"
+              exit 1
+            fi
+            echo "PASS: counter ${counter} exposed"
+          done
+
+          # After the /shadow hit above, dry_run_requests_total must be >= 1.
+          dry_run_total=$(echo "$metrics_resp" | awk '/^l402_dry_run_requests_total / {print $2}')
+          if [ -z "$dry_run_total" ] || [ "$dry_run_total" -lt 1 ]; then
+            echo "FAIL: l402_dry_run_requests_total=$dry_run_total, expected >= 1"
+            echo "$metrics_resp"
+            exit 1
+          fi
+          echo "PASS: l402_dry_run_requests_total=$dry_run_total"
+
+          echo "✅ Dry-run shadow mode & metrics integration tests completed!"
+
       - name: Run Integration Tests - gRPC
         run: |
           docker logs grpc-content-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY nginx.conf /etc/nginx/nginx.conf
 COPY index.html /usr/share/nginx/html/protected/index.html
 COPY index.html /usr/share/nginx/html/protected-timeout/index.html
 COPY index.html /usr/share/nginx/html/rate-limited/index.html
+COPY index.html /usr/share/nginx/html/shadow/index.html
 COPY index.html /usr/share/nginx/html/tenant1/index.html
 COPY index.html /usr/share/nginx/html/tenant2/index.html
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For local contributor setup on macOS (Docker nginx recommended), see `docs/macos
 - [Configuration & Environment Variables](https://dhananjaypurohit.github.io/ngx_l402/config-env-vars.html)
 - [Cashu eCash Support](https://dhananjaypurohit.github.io/ngx_l402/cashu.html)
 - [Multi-Tenant](https://dhananjaypurohit.github.io/ngx_l402/config-multi-tenant.html)
+- [Dry-Run (Shadow) Mode](https://dhananjaypurohit.github.io/ngx_l402/dry-run.html)
 - [Building from Source](https://dhananjaypurohit.github.io/ngx_l402/building.html)
 
 ---
@@ -48,39 +49,6 @@ Test it:
 curl http://localhost:8000/           # 200 OK
 curl -i http://localhost:8000/protected  # 402 Payment Required
 ```
-
----
-
-## Shadow mode (safe rollouts)
-
-Before switching a route to enforced L402 in production, you can run it in
-**shadow mode** to validate pricing, LN backend reachability, and traffic
-patterns *without* blocking any requests:
-
-```nginx
-location /api/ {
-    l402                        on;
-    l402_amount_msat_default    10000;
-    l402_dry_run                on;      # evaluate, log, never block
-    proxy_pass                  http://upstream;
-}
-
-location = /metrics {
-    l402_metrics;                         # Prometheus scrape endpoint
-}
-```
-
-In shadow mode the module:
-
-- Evaluates the full pricing pipeline (static config + Redis overrides).
-- Attempts to synthesise a valid L402 challenge and exposes it via the
-  `X-L402-Dry-Run-Challenge` response header.
-- Emits one structured JSON log line per request (route, price, backend,
-  client IP, auth state, would-be status).
-- Updates `l402_dry_run_*` Prometheus counters.
-- **Always returns 200 OK to the client.**
-
-See [`nginx.conf`](nginx.conf) for a worked example.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,39 @@ curl -i http://localhost:8000/protected  # 402 Payment Required
 
 ---
 
+## Shadow mode (safe rollouts)
+
+Before switching a route to enforced L402 in production, you can run it in
+**shadow mode** to validate pricing, LN backend reachability, and traffic
+patterns *without* blocking any requests:
+
+```nginx
+location /api/ {
+    l402                        on;
+    l402_amount_msat_default    10000;
+    l402_dry_run                on;      # evaluate, log, never block
+    proxy_pass                  http://upstream;
+}
+
+location = /metrics {
+    l402_metrics;                         # Prometheus scrape endpoint
+}
+```
+
+In shadow mode the module:
+
+- Evaluates the full pricing pipeline (static config + Redis overrides).
+- Attempts to synthesise a valid L402 challenge and exposes it via the
+  `X-L402-Dry-Run-Challenge` response header.
+- Emits one structured JSON log line per request (route, price, backend,
+  client IP, auth state, would-be status).
+- Updates `l402_dry_run_*` Prometheus counters.
+- **Always returns 200 OK to the client.**
+
+See [`nginx.conf`](nginx.conf) for a worked example.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,3 +24,4 @@
 
 - [Building from Source](./building.md)
 - [Logging](./logging.md)
+- [Dry-Run (Shadow) Mode](./dry-run.md)

--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -53,6 +53,12 @@ For every request reaching a shadow-mode location, the module:
 > unauthenticated request. If you have high traffic, start by enabling
 > shadow mode on a sampled location (e.g. a canary route) before rolling
 > it out everywhere.
+>
+> **Latency cap**: the challenge-synthesis call is bounded by a 5-second
+> timeout. If the LN backend does not respond within that window the
+> request still passes through (with no `X-L402-Dry-Run-Challenge`
+> header) and `l402_dry_run_challenge_errors_total` is incremented —
+> shadow mode must never add latency to user-facing traffic.
 
 ---
 

--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -1,0 +1,192 @@
+# Dry-Run (Shadow) Mode
+
+Shadow mode lets operators roll out L402 enforcement safely. With
+`l402_dry_run on;` set on a location, the module evaluates the full pricing
+pipeline, synthesises a valid L402 challenge, and records structured logs
+and Prometheus metrics — but **always passes the request through to the
+upstream**. No client ever sees `401` or `402`.
+
+This is the recommended way to validate pricing, LN backend reachability,
+and traffic patterns with real production traffic before flipping a route
+to enforcement.
+
+---
+
+## Enabling shadow mode
+
+```nginx
+location /api/ {
+    l402                        on;
+    l402_amount_msat_default    10000;
+    l402_dry_run                on;          # evaluate, log, never block
+    proxy_pass                  http://upstream;
+}
+```
+
+`l402_dry_run` accepts `on` or `off` (default). It can be combined with any
+other `l402_*` directive — dynamic pricing from Redis, multi-tenant LNURLs,
+macaroon timeouts, invoice rate limits — so the shadow-mode numbers you
+measure match the configuration you are about to enforce.
+
+`l402` must still be `on` for the module to enter the access handler.
+Turning `l402` off disables the module entirely, including shadow mode.
+
+---
+
+## What happens per request
+
+For every request reaching a shadow-mode location, the module:
+
+1. Reads the static and dynamic (Redis) price for the route and picks the
+   effective `amount_msat`.
+2. Looks up any per-tenant LNURL override.
+3. Verifies the `Authorization` header if one is present (L402 or Cashu).
+4. If no valid token is present, calls the configured LN backend and
+   generates a real invoice + macaroon — exactly the challenge enforce
+   mode would have returned.
+5. Emits a structured JSON log line and bumps the relevant Prometheus
+   counters.
+6. Returns `NGX_DECLINED`, so Nginx continues to the content phase and
+   serves the upstream response with its natural status code.
+
+> **Cost note**: generating a challenge contacts your LN backend on every
+> unauthenticated request. If you have high traffic, start by enabling
+> shadow mode on a sampled location (e.g. a canary route) before rolling
+> it out everywhere.
+
+---
+
+## Response headers
+
+Shadow mode attaches debug headers to the upstream response so operators
+can inspect what would have happened without scraping logs:
+
+| Header | Meaning |
+|---|---|
+| `X-L402-Dry-Run: 1` | Marks the response as produced by shadow mode. |
+| `X-L402-Dry-Run-Price-Msat: <n>` | Effective price for this route. |
+| `X-L402-Dry-Run-Challenge: L402 macaroon="...", invoice="..."` | The exact `WWW-Authenticate` value enforce mode would have returned. Only present when the request would have been challenged (`402`). |
+| `WWW-Authenticate: L402 macaroon="...", invoice="..."` | Also set, so real L402 clients can follow the payment flow in a staging environment. |
+
+---
+
+## Structured log events
+
+Every shadow-mode request produces a single `info`-level JSON line via the
+Rust logger. A minimal example (formatted for readability):
+
+```json
+{
+  "event": "l402_dry_run",
+  "route": "/api/resource",
+  "price_msat": 10000,
+  "price_source": "static",
+  "backend": "LNURL",
+  "client_ip": "203.0.113.42",
+  "auth_state": "missing",
+  "would_return": 402
+}
+```
+
+Fields:
+
+| Field | Values |
+|---|---|
+| `route` | Normalised request path used for pricing lookups. |
+| `price_msat` | Effective price in millisatoshis. |
+| `price_source` | `static` (from `nginx.conf`) or `dynamic` (from Redis). |
+| `backend` | LN backend type snapshot: `LND`, `LNURL`, `NWC`, `CLN`, `BOLT12`, `ECLAIR`. |
+| `client_ip` | From `X-Real-IP` → `X-Forwarded-For` → socket address. |
+| `auth_state` | `missing`, `valid`, or `invalid`. |
+| `would_return` | HTTP status enforce mode *would* have used (`200`, `401`, `402`). |
+
+Pipe into `jq` to see a live firehose:
+
+```bash
+sudo tail -f /var/log/nginx/error.log \
+  | grep '"event":"l402_dry_run"' \
+  | jq -c 'select(.would_return != 200) | {route, price_msat, auth_state}'
+```
+
+---
+
+## Prometheus metrics
+
+The `l402_metrics` directive turns a location into a Prometheus scrape
+endpoint. It serves counters in text exposition format v0.0.4.
+
+```nginx
+location = /metrics {
+    l402_metrics;
+
+    # Production: restrict to your scrape network.
+    allow 10.0.0.0/8;
+    deny  all;
+}
+```
+
+Scrape it with a standard Prometheus config:
+
+```yaml
+scrape_configs:
+  - job_name: ngx_l402
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['nginx:8000']
+```
+
+### Exported counters
+
+| Metric | Meaning |
+|---|---|
+| `l402_requests_total` | Every request that entered the access handler with `l402 on;`. |
+| `l402_challenges_issued_total` | Requests that received a `402` response (enforce mode). |
+| `l402_payments_valid_total` | Authorization headers that verified successfully. |
+| `l402_payments_invalid_total` | Authorization headers that failed verification. |
+| `l402_payments_missing_total` | Requests without an Authorization header. |
+| `l402_dry_run_requests_total` | Requests handled in shadow mode. |
+| `l402_dry_run_would_block_total` | Shadow-mode requests that *would* have been blocked (`401` or `402`). |
+| `l402_dry_run_would_allow_total` | Shadow-mode requests that *would* have been allowed (`200`). |
+| `l402_dry_run_challenge_errors_total` | Shadow-mode requests where challenge synthesis failed (e.g. LN backend unreachable). |
+| `l402_dry_run_price_msat_sum` | Sum of msat prices evaluated in shadow mode. Pair with `_requests_total` to derive an average price. |
+
+### Useful PromQL
+
+```promql
+# Fraction of traffic that would be blocked if you flipped enforcement on:
+rate(l402_dry_run_would_block_total[5m])
+/
+rate(l402_dry_run_requests_total[5m])
+
+# Average price served by shadow mode (msat):
+rate(l402_dry_run_price_msat_sum[5m])
+/
+rate(l402_dry_run_requests_total[5m])
+
+# Challenge-synthesis error rate — a signal that your LN backend is flaky:
+rate(l402_dry_run_challenge_errors_total[5m])
+```
+
+> The endpoint has no built-in authentication. Restrict it at the Nginx
+> level with `allow`/`deny`, an auth subrequest, or a firewall rule —
+> exposing it publicly leaks traffic volume and pricing details.
+
+---
+
+## Suggested rollout recipe
+
+1. Deploy with `l402 on;` and `l402_dry_run on;` on the target location.
+   Leave existing routes untouched.
+2. Scrape `/metrics` for 24–48 hours. Confirm:
+   - `l402_dry_run_challenge_errors_total` stays flat (LN backend healthy).
+   - `l402_dry_run_would_allow_total / l402_dry_run_requests_total` matches
+     the fraction of paying clients you expect.
+   - `l402_dry_run_price_msat_sum` divided by request count matches your
+     posted price.
+3. Sample the JSON log for a few high-volume paths and confirm
+   `price_source` is what you configured (`static` vs `dynamic`).
+4. Remove `l402_dry_run on;` (or set it to `off`). Reload Nginx. The
+   location now enforces.
+
+If you ever need to revert, setting `l402_dry_run on;` again immediately
+disables enforcement without touching upstream code paths.

--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -63,10 +63,11 @@ can inspect what would have happened without scraping logs:
 
 | Header | Meaning |
 |---|---|
-| `X-L402-Dry-Run: 1` | Marks the response as produced by shadow mode. |
-| `X-L402-Dry-Run-Price-Msat: <n>` | Effective price for this route. |
-| `X-L402-Dry-Run-Challenge: L402 macaroon="...", invoice="..."` | The exact `WWW-Authenticate` value enforce mode would have returned. Only present when the request would have been challenged (`402`). |
-| `WWW-Authenticate: L402 macaroon="...", invoice="..."` | Also set, so real L402 clients can follow the payment flow in a staging environment. |
+| `X-L402-Dry-Run: 1` | Marks the response as produced by shadow mode. Always present. |
+| `X-L402-Dry-Run-Price-Msat: <n>` | Effective price for this route. Only emitted when the request *would* have been challenged (`402`) — not on paid-valid or rejected-invalid responses, to avoid leaking pricing against decided traffic. |
+| `X-L402-Dry-Run-Challenge: L402 macaroon="...", invoice="..."` | The exact `WWW-Authenticate` value enforce mode would have returned. Only present when the request would have been challenged (`402`) and the LN backend produced an invoice. |
+| `WWW-Authenticate: L402 macaroon="...", invoice="..."` | Also set alongside the challenge header, so real L402 clients can follow the payment flow in a staging environment. |
+| `X-L402-Dry-Run-Rate-Limited: 1` + `X-L402-Dry-Run-Retry-After: <sec>` | Set when the request would have been challenged but hit `l402_invoice_rate_limit`. No invoice is generated and no challenge header is attached, mirroring what enforce mode would have done (429 + `Retry-After`). |
 
 ---
 
@@ -99,6 +100,7 @@ Fields:
 | `client_ip` | From `X-Real-IP` → `X-Forwarded-For` → socket address. |
 | `auth_state` | `missing`, `valid`, or `invalid`. |
 | `would_return` | HTTP status enforce mode *would* have used (`200`, `401`, `402`). |
+| `rate_limited` | `true` when `l402_invoice_rate_limit` would have produced a `429` — challenge synthesis was skipped to protect the LN backend. |
 
 Pipe into `jq` to see a live firehose:
 
@@ -139,14 +141,16 @@ scrape_configs:
 
 | Metric | Meaning |
 |---|---|
-| `l402_requests_total` | Every request that entered the access handler with `l402 on;`. |
-| `l402_challenges_issued_total` | Requests that received a `402` response (enforce mode). |
-| `l402_payments_valid_total` | Authorization headers that verified successfully. |
-| `l402_payments_invalid_total` | Authorization headers that failed verification. |
-| `l402_payments_missing_total` | Requests without an Authorization header. |
+| `l402_requests_total` | Every request that entered the access handler with `l402 on;`. Incremented for both enforce and shadow traffic. |
+| `l402_challenges_issued_total` | Requests that received a `402` response (enforce mode), counted *after* the rate-limit gate. |
+| `l402_rate_limited_total` | Requests rejected with `429` by `l402_invoice_rate_limit` (enforce mode). |
+| `l402_payments_valid_total` | Authorization headers that verified successfully (enforce mode only — dry-run traffic goes to `l402_dry_run_*`). |
+| `l402_payments_invalid_total` | Authorization headers that failed verification (enforce mode only). |
+| `l402_payments_missing_total` | Requests without an Authorization header (enforce mode only). |
 | `l402_dry_run_requests_total` | Requests handled in shadow mode. |
 | `l402_dry_run_would_block_total` | Shadow-mode requests that *would* have been blocked (`401` or `402`). |
 | `l402_dry_run_would_allow_total` | Shadow-mode requests that *would* have been allowed (`200`). |
+| `l402_dry_run_rate_limited_total` | Shadow-mode requests that would have hit `l402_invoice_rate_limit` — challenge synthesis was skipped. |
 | `l402_dry_run_challenge_errors_total` | Shadow-mode requests where challenge synthesis failed (e.g. LN backend unreachable). |
 | `l402_dry_run_price_msat_sum` | Sum of msat prices evaluated in shadow mode. Pair with `_requests_total` to derive an average price. |
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -82,6 +82,27 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
+        # Shadow-mode endpoint: L402 is evaluated (pricing, challenge
+        # generation, structured logs, Prometheus counters) but payment is
+        # NOT enforced. All requests return 200 OK regardless of the
+        # Authorization header. Use this for safe production rollouts.
+        location /shadow {
+            root   /usr/share/nginx/html;
+            l402    on;
+            l402_amount_msat_default    10000;
+            l402_macaroon_timeout 0;
+            l402_dry_run on;
+
+            try_files $uri $uri/index.html =404;
+        }
+
+        # Prometheus scrape endpoint. Emits `l402_*` and `l402_dry_run_*`
+        # counters in text exposition format (v0.0.4). No authentication;
+        # restrict access via `allow`/`deny` or a firewall in production.
+        location = /metrics {
+            l402_metrics;
+        }
+
         # Rate-limited endpoint: only 2 invoices per minute per IP.
         # Used by the invoice rate limiting integration tests.
         location /rate-limited {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,7 @@ fn is_preimage_used(preimage: &[u8]) -> bool {
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(e) => {
-            error!(
-                "❌ Failed to get Redis connection from pool for preimage check: {}",
-                e
-            );
+            error!("❌ Failed to get Redis connection from pool for preimage check: {}", e);
             return false;
         }
     };
@@ -189,10 +186,7 @@ pub fn is_cashu_token_used(token: &str) -> bool {
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(e) => {
-            error!(
-                "❌ Failed to get Redis connection from pool for Cashu token check: {}",
-                e
-            );
+            error!("❌ Failed to get Redis connection from pool for Cashu token check: {}", e);
             return false;
         }
     };
@@ -277,19 +271,21 @@ impl L402Module {
                 .unwrap_or(default_pool_size);
 
             match RedisClient::open(redis_url.clone()) {
-                Ok(manager) => match Pool::builder().max_size(pool_size).build(manager) {
-                    Ok(pool) => {
-                        if REDIS_POOL.set(pool).is_ok() {
-                            info!(
-                                "✅ Redis connection pool ready (max_size={}) at {}",
-                                pool_size, redis_url
-                            );
-                        } else {
-                            error!("❌ Failed to register Redis pool in OnceLock");
+                Ok(manager) => {
+                    match Pool::builder().max_size(pool_size).build(manager) {
+                        Ok(pool) => {
+                            if REDIS_POOL.set(pool).is_ok() {
+                                info!(
+                                    "✅ Redis connection pool ready (max_size={}) at {}",
+                                    pool_size, redis_url
+                                );
+                            } else {
+                                error!("❌ Failed to register Redis pool in OnceLock");
+                            }
                         }
+                        Err(e) => error!("❌ Failed to build Redis connection pool: {}", e),
                     }
-                    Err(e) => error!("❌ Failed to build Redis connection pool: {}", e),
-                },
+                }
                 Err(e) => error!("❌ Failed to create Redis client: {}", e),
             }
         } else {
@@ -698,8 +694,10 @@ pub struct ModuleConfig {
     // None means rate limiting is disabled for this location.
     invoice_rate_limit: Option<(u32, u64)>,
     // Shadow mode: evaluate pricing and generate challenges but never block
-    // the request. Used for safe production rollouts.
-    dry_run: bool,
+    // the request. Used for safe production rollouts. `None` means unset
+    // (inherit from parent scope); `Some(false)` explicitly turns it off and
+    // stops inheritance.
+    dry_run: Option<bool>,
 }
 
 pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 8] = [
@@ -829,8 +827,10 @@ impl Merge for ModuleConfig {
         if self.invoice_rate_limit.is_none() {
             self.invoice_rate_limit = prev.invoice_rate_limit;
         }
-        if prev.dry_run && !self.dry_run {
-            self.dry_run = true;
+        // Standard "child wins if set" merge — `l402_dry_run off;` in an inner
+        // location overrides `l402_dry_run on;` on the outer scope.
+        if self.dry_run.is_none() {
+            self.dry_run = prev.dry_run;
         }
         Ok(())
     }
@@ -908,7 +908,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
 
         let lnurl_addr = conf.lnurl_addr.clone();
         let invoice_rate_limit = conf.invoice_rate_limit;
-        let dry_run = conf.dry_run;
+        let dry_run = conf.dry_run.unwrap_or(false);
 
         (
             auth_header,
@@ -965,13 +965,6 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         final_lnurl_addr.clone(),
     );
 
-    match result {
-        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
-        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
-        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
-        _ => {}
-    }
-
     if dry_run {
         return handle_dry_run_passthrough(
             request,
@@ -985,15 +978,25 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             caveats,
             result,
             auth_present,
+            invoice_rate_limit,
         );
+    }
+
+    // Enforce-mode outcome counters. Deliberately skipped above for dry-run
+    // so shadow traffic doesn't pollute enforce-mode SLO dashboards.
+    match result {
+        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
+        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
+        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
+        _ => {}
     }
 
     // Only set L402 header if result is 402
     if result == 402 {
-        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
+                metrics::inc(&metrics::L402_RATE_LIMITED_TOTAL);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
@@ -1010,6 +1013,8 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 return 429;
             }
         }
+        // Only count as "issued" once we're past the rate-limit gate.
+        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
 
         // Use a lazily initialized static runtime
         static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -1479,6 +1484,7 @@ fn handle_dry_run_passthrough(
     caveats: Vec<String>,
     result: isize,
     auth_present: bool,
+    invoice_rate_limit: Option<(u32, u64)>,
 ) -> isize {
     metrics::inc(&metrics::L402_DRY_RUN_REQUESTS_TOTAL);
     if final_amount > 0 {
@@ -1492,10 +1498,29 @@ fn handle_dry_run_passthrough(
         other if (100..600).contains(&other) => other as u16,
         _ => 0,
     };
+
+    // Check the invoice rate limiter when an invoice *would* be issued.
+    // Without this, dry-run mode can hit the LN backend harder than enforce
+    // mode — the opposite of what "safe rollout" should mean.
+    let client_ip = get_client_ip(request);
+    let rate_limited = if would_return == 402 {
+        match invoice_rate_limit {
+            Some((max_requests, window_secs)) => {
+                !check_invoice_rate_limit(&client_ip, request_path, max_requests, window_secs)
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
+
     match would_return {
         200 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_ALLOW_TOTAL),
         401 | 402 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_BLOCK_TOTAL),
         _ => {}
+    }
+    if rate_limited {
+        metrics::inc(&metrics::L402_DRY_RUN_RATE_LIMITED_TOTAL);
     }
 
     let auth_state = match (auth_present, result) {
@@ -1504,7 +1529,6 @@ fn handle_dry_run_passthrough(
         (true, _) => "invalid",
     };
 
-    let client_ip = get_client_ip(request);
     let backend = LN_BACKEND_LABEL
         .get()
         .map(String::as_str)
@@ -1513,7 +1537,7 @@ fn handle_dry_run_passthrough(
     // Structured JSON line — easy to pick out of nginx error_log with jq/grep
     // and forward to Loki / Splunk / Datadog.
     info!(
-        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status}}}",
+        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status},\"rate_limited\":{rl}}}",
         route = escape_json(request_path),
         price = final_amount,
         src = price_source,
@@ -1521,9 +1545,17 @@ fn handle_dry_run_passthrough(
         ip = escape_json(&client_ip),
         state = auth_state,
         status = would_return,
+        rl = rate_limited,
     );
 
-    if would_return == 402 {
+    // SAFETY: `request` is non-null and valid for this handler's lifetime,
+    // as guaranteed by nginx before invoking the access handler.
+    let req = unsafe { Request::from_ngx_http_request(request) };
+    req.add_header_out("X-L402-Dry-Run", "1");
+
+    if would_return == 402 && !rate_limited {
+        req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+
         let rt = dry_run_runtime();
         let header_result = rt.block_on(async {
             module
@@ -1533,15 +1565,8 @@ fn handle_dry_run_passthrough(
 
         match header_result {
             Some(header_value) => {
-                // SAFETY: `request` is non-null and valid for this handler's
-                // lifetime, as guaranteed by nginx before invoking the handler.
-                unsafe {
-                    let req = Request::from_ngx_http_request(request);
-                    req.add_header_out("WWW-Authenticate", &header_value);
-                    req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
-                    req.add_header_out("X-L402-Dry-Run", "1");
-                    req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
-                }
+                req.add_header_out("WWW-Authenticate", &header_value);
+                req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
             }
             None => {
                 metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
@@ -1553,15 +1578,23 @@ fn handle_dry_run_passthrough(
                 );
             }
         }
-    } else {
-        // Still advertise the mode via a cheap header so clients know
-        // this route would normally be paid.
-        unsafe {
-            let req = Request::from_ngx_http_request(request);
-            req.add_header_out("X-L402-Dry-Run", "1");
-            req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+    } else if would_return == 402 && rate_limited {
+        // Rate-limited: surface the signal without hitting the LN backend.
+        req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+        req.add_header_out("X-L402-Dry-Run-Rate-Limited", "1");
+        if let Some((_, window_secs)) = invoice_rate_limit {
+            req.add_header_out("X-L402-Dry-Run-Retry-After", &window_secs.to_string());
         }
+        ngx_log_error!(
+            NGX_LOG_WARN,
+            log_ref,
+            "[l402_dry_run] invoice rate limit exceeded for IP={} path={}",
+            client_ip,
+            request_path
+        );
     }
+    // `would_return` 200/401 fall through with just `X-L402-Dry-Run: 1`:
+    // no price leak on paid-valid, no challenge replay on bad token.
 
     NGX_DECLINED as isize
 }
@@ -1675,10 +1708,10 @@ pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
         let val = (*args.add(1)).to_str();
 
         if val.eq_ignore_ascii_case("on") {
-            conf.dry_run = true;
+            conf.dry_run = Some(true);
             info!("⚙️ l402_dry_run enabled (shadow mode — requests will pass through)");
         } else if val.eq_ignore_ascii_case("off") {
-            conf.dry_run = false;
+            conf.dry_run = Some(false);
         } else {
             error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
             return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
@@ -1699,6 +1732,14 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
         let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
         if clcf.is_null() {
             return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
+        }
+        // Refuse to silently clobber a content handler registered by another
+        // directive (e.g. `proxy_pass`, `return`, `alias` + `try_files`, etc.).
+        // Fail fast at `nginx -t` rather than surprise operators at runtime.
+        if (*clcf).handler.is_some() {
+            error!("l402_metrics: another content handler is already registered for this location");
+            return b"l402_metrics: conflicts with another content handler in this location\0"
+                .as_ptr() as *mut c_char;
         }
         (*clcf).handler = Some(l402_metrics_content_handler);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use std::ptr::addr_of;
 use std::sync::Arc;
 use std::sync::Once;
 use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use tonic_openssl_lnd::lnrpc;
 
@@ -1556,24 +1556,47 @@ fn handle_dry_run_passthrough(
     if would_return == 402 && !rate_limited {
         req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
 
+        // Hard cap on the LN backend round-trip. Shadow mode must not add
+        // latency to upstream traffic: if the backend stalls we bail out,
+        // count a challenge error, and pass the request through without a
+        // challenge header.
+        const DRY_RUN_CHALLENGE_TIMEOUT: Duration = Duration::from_secs(5);
+
         let rt = dry_run_runtime();
         let header_result = rt.block_on(async {
-            module
-                .get_l402_header(caveats, final_amount, macaroon_timeout, final_lnurl_addr)
-                .await
+            tokio::time::timeout(
+                DRY_RUN_CHALLENGE_TIMEOUT,
+                module.get_l402_header(
+                    caveats,
+                    final_amount,
+                    macaroon_timeout,
+                    final_lnurl_addr,
+                ),
+            )
+            .await
         });
 
         match header_result {
-            Some(header_value) => {
+            Ok(Some(header_value)) => {
                 req.add_header_out("WWW-Authenticate", &header_value);
                 req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
             }
-            None => {
+            Ok(None) => {
                 metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
                     "[l402_dry_run] failed to synthesise challenge for {}",
+                    request_path
+                );
+            }
+            Err(_) => {
+                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                ngx_log_error!(
+                    NGX_LOG_WARN,
+                    log_ref,
+                    "[l402_dry_run] challenge synthesis timed out after {}s for {}",
+                    DRY_RUN_CHALLENGE_TIMEOUT.as_secs(),
                     request_path
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,20 @@ use l402_middleware::middleware::L402Middleware;
 use l402_middleware::{bolt12, cln, eclair, l402, lnclient, lnd, lnurl, macaroon_util, nwc, utils};
 use log::{debug, error, info, warn};
 use macaroon::Verifier;
+use ngx::core::Buffer;
 use ngx::ffi::{
-    nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_cycle_s, ngx_http_core_module,
-    ngx_http_handler_pt, ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE,
-    ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t, ngx_str_t, ngx_uint_t, NGX_CONF_TAKE1,
-    NGX_DECLINED, NGX_ERROR, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_LOG_ERR, NGX_LOG_INFO,
-    NGX_LOG_WARN, NGX_OK,
+    nginx_version, ngx_array_push, ngx_chain_t, ngx_command_t, ngx_conf_t, ngx_cycle_s,
+    ngx_http_core_module, ngx_http_discard_request_body, ngx_http_handler_pt, ngx_http_module_t,
+    ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t,
+    ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_GET,
+    NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE,
+    NGX_HTTP_NOT_ALLOWED, NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_WARN, NGX_OK,
     NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::http::{ngx_http_conf_get_module_main_conf, HTTPModule, Merge, MergeConfigError, Request};
+use ngx::http::{
+    ngx_http_conf_get_module_loc_conf, ngx_http_conf_get_module_main_conf, HTTPModule, HTTPStatus,
+    Merge, MergeConfigError, Request,
+};
 use ngx::{ngx_log_error, ngx_null_command, ngx_string};
 use r2d2::Pool;
 use redis::Client as RedisClient;
@@ -32,6 +37,7 @@ use tonic_openssl_lnd::lnrpc;
 
 mod cashu;
 mod cashu_redemption_logger;
+mod metrics;
 
 static INIT: Once = Once::new();
 static mut MODULE: Option<L402Module> = None;
@@ -43,6 +49,10 @@ static REDIS_POOL: OnceLock<Pool<RedisClient>> = OnceLock::new();
 static LNURL_CLIENT_CACHE: OnceLock<
     tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<dyn lnclient::LNClient + Send>>>>,
 > = OnceLock::new();
+
+/// Configured LN backend type (`LNURL`, `LND`, `NWC`, ...) captured once at
+/// init for use in structured dry-run log lines.
+static LN_BACKEND_LABEL: OnceLock<String> = OnceLock::new();
 
 /// Get or create a cached LNURL client for the given address
 /// This function is also used by cashu.rs for multi-tenant redemption
@@ -106,7 +116,10 @@ fn is_preimage_used(preimage: &[u8]) -> bool {
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(e) => {
-            error!("❌ Failed to get Redis connection from pool for preimage check: {}", e);
+            error!(
+                "❌ Failed to get Redis connection from pool for preimage check: {}",
+                e
+            );
             return false;
         }
     };
@@ -176,7 +189,10 @@ pub fn is_cashu_token_used(token: &str) -> bool {
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(e) => {
-            error!("❌ Failed to get Redis connection from pool for Cashu token check: {}", e);
+            error!(
+                "❌ Failed to get Redis connection from pool for Cashu token check: {}",
+                e
+            );
             return false;
         }
     };
@@ -261,21 +277,19 @@ impl L402Module {
                 .unwrap_or(default_pool_size);
 
             match RedisClient::open(redis_url.clone()) {
-                Ok(manager) => {
-                    match Pool::builder().max_size(pool_size).build(manager) {
-                        Ok(pool) => {
-                            if REDIS_POOL.set(pool).is_ok() {
-                                info!(
-                                    "✅ Redis connection pool ready (max_size={}) at {}",
-                                    pool_size, redis_url
-                                );
-                            } else {
-                                error!("❌ Failed to register Redis pool in OnceLock");
-                            }
+                Ok(manager) => match Pool::builder().max_size(pool_size).build(manager) {
+                    Ok(pool) => {
+                        if REDIS_POOL.set(pool).is_ok() {
+                            info!(
+                                "✅ Redis connection pool ready (max_size={}) at {}",
+                                pool_size, redis_url
+                            );
+                        } else {
+                            error!("❌ Failed to register Redis pool in OnceLock");
                         }
-                        Err(e) => error!("❌ Failed to build Redis connection pool: {}", e),
                     }
-                }
+                    Err(e) => error!("❌ Failed to build Redis connection pool: {}", e),
+                },
                 Err(e) => error!("❌ Failed to create Redis client: {}", e),
             }
         } else {
@@ -683,9 +697,12 @@ pub struct ModuleConfig {
     // (max_requests, window_secs): e.g. (5, 60) means 5 invoices per minute per IP per route.
     // None means rate limiting is disabled for this location.
     invoice_rate_limit: Option<(u32, u64)>,
+    // Shadow mode: evaluate pricing and generate challenges but never block
+    // the request. Used for safe production rollouts.
+    dry_run: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 6] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 8] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -722,6 +739,22 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 6] = [
         name: ngx_string!("l402_invoice_rate_limit"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
         set: Some(ngx_http_l402_invoice_rate_limit_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_dry_run"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
+        set: Some(ngx_http_l402_dry_run_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_metrics"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
+        set: Some(ngx_http_l402_metrics_set),
         conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
         offset: 0,
         post: std::ptr::null_mut(),
@@ -796,6 +829,9 @@ impl Merge for ModuleConfig {
         if self.invoice_rate_limit.is_none() {
             self.invoice_rate_limit = prev.invoice_rate_limit;
         }
+        if prev.dry_run && !self.dry_run {
+            self.dry_run = true;
+        }
         Ok(())
     }
 }
@@ -822,6 +858,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         macaroon_timeout,
         lnurl_addr,
         invoice_rate_limit,
+        dry_run,
     ) = unsafe {
         // NOTE: `authorization` can be null — not every request carries the header.
         let auth_header = if !r.headers_in.authorization.is_null() {
@@ -871,6 +908,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
 
         let lnurl_addr = conf.lnurl_addr.clone();
         let invoice_rate_limit = conf.invoice_rate_limit;
+        let dry_run = conf.dry_run;
 
         (
             auth_header,
@@ -880,6 +918,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             macaroon_timeout,
             lnurl_addr,
             invoice_rate_limit,
+            dry_run,
         )
     };
 
@@ -905,11 +944,18 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     } else {
         amount_msat
     };
+    let price_source = if dynamic_amount > 0 {
+        "dynamic"
+    } else {
+        "static"
+    };
 
     // Get dynamic LNURL from Redis (takes precedence over nginx config)
     let dynamic_lnurl = module.get_dynamic_lnurl(&request_path);
     let final_lnurl_addr = dynamic_lnurl.or(lnurl_addr);
 
+    metrics::inc(&metrics::L402_REQUESTS_TOTAL);
+    let auth_present = auth_header.is_some();
     let result = l402_access_handler(
         auth_header,
         uri,
@@ -919,8 +965,32 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         final_lnurl_addr.clone(),
     );
 
+    match result {
+        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
+        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
+        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
+        _ => {}
+    }
+
+    if dry_run {
+        return handle_dry_run_passthrough(
+            request,
+            log_ref,
+            module,
+            &request_path,
+            final_amount,
+            price_source,
+            final_lnurl_addr,
+            macaroon_timeout,
+            caveats,
+            result,
+            auth_present,
+        );
+    }
+
     // Only set L402 header if result is 402
     if result == 402 {
+        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
@@ -1188,6 +1258,11 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     info!("🚀 Starting L402 module initialization");
     ngx_log_error!(NGX_LOG_INFO, log, "Starting module initialization");
 
+    // Cache the LN backend type string for structured log lines. We can't
+    // read env vars from worker threads, so snapshot it here.
+    let _ = LN_BACKEND_LABEL
+        .set(std::env::var("LN_CLIENT_TYPE").unwrap_or_else(|_| "LNURL".to_string()));
+
     // Check if Cashu eCash support is enabled
     let cashu_ecash_support_var =
         std::env::var("CASHU_ECASH_SUPPORT").unwrap_or_else(|_| "false".to_string());
@@ -1380,6 +1455,255 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
             });
     }
     0
+}
+
+/// Handle dry-run (shadow) mode: evaluate everything, log + increment metrics,
+/// but never block the request. Always returns [`NGX_DECLINED`] so nginx
+/// continues to the next phase and the upstream response is served as 200.
+///
+/// A synthesised L402 challenge is attached via the `WWW-Authenticate` *and*
+/// `X-L402-Dry-Run-Challenge` response headers so operators can inspect the
+/// challenge that *would* have been issued without parsing logs. Failure to
+/// generate the challenge (e.g. LN backend unreachable) is counted but does
+/// not fail the request.
+#[allow(clippy::too_many_arguments)]
+fn handle_dry_run_passthrough(
+    request: *mut ngx_http_request_t,
+    log_ref: *mut ngx_log_s,
+    module: &L402Module,
+    request_path: &str,
+    final_amount: i64,
+    price_source: &'static str,
+    final_lnurl_addr: Option<String>,
+    macaroon_timeout: i64,
+    caveats: Vec<String>,
+    result: isize,
+    auth_present: bool,
+) -> isize {
+    metrics::inc(&metrics::L402_DRY_RUN_REQUESTS_TOTAL);
+    if final_amount > 0 {
+        metrics::add(&metrics::L402_DRY_RUN_PRICE_MSAT_SUM, final_amount as u64);
+    }
+
+    let would_return: u16 = match result {
+        r if r == NGX_DECLINED as isize => 200,
+        401 => 401,
+        402 => 402,
+        other if (100..600).contains(&other) => other as u16,
+        _ => 0,
+    };
+    match would_return {
+        200 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_ALLOW_TOTAL),
+        401 | 402 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_BLOCK_TOTAL),
+        _ => {}
+    }
+
+    let auth_state = match (auth_present, result) {
+        (false, _) => "missing",
+        (true, r) if r == NGX_DECLINED as isize => "valid",
+        (true, _) => "invalid",
+    };
+
+    let client_ip = get_client_ip(request);
+    let backend = LN_BACKEND_LABEL
+        .get()
+        .map(String::as_str)
+        .unwrap_or("unknown");
+
+    // Structured JSON line — easy to pick out of nginx error_log with jq/grep
+    // and forward to Loki / Splunk / Datadog.
+    info!(
+        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status}}}",
+        route = escape_json(request_path),
+        price = final_amount,
+        src = price_source,
+        backend = backend,
+        ip = escape_json(&client_ip),
+        state = auth_state,
+        status = would_return,
+    );
+
+    if would_return == 402 {
+        let rt = dry_run_runtime();
+        let header_result = rt.block_on(async {
+            module
+                .get_l402_header(caveats, final_amount, macaroon_timeout, final_lnurl_addr)
+                .await
+        });
+
+        match header_result {
+            Some(header_value) => {
+                // SAFETY: `request` is non-null and valid for this handler's
+                // lifetime, as guaranteed by nginx before invoking the handler.
+                unsafe {
+                    let req = Request::from_ngx_http_request(request);
+                    req.add_header_out("WWW-Authenticate", &header_value);
+                    req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
+                    req.add_header_out("X-L402-Dry-Run", "1");
+                    req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+                }
+            }
+            None => {
+                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                ngx_log_error!(
+                    NGX_LOG_WARN,
+                    log_ref,
+                    "[l402_dry_run] failed to synthesise challenge for {}",
+                    request_path
+                );
+            }
+        }
+    } else {
+        // Still advertise the mode via a cheap header so clients know
+        // this route would normally be paid.
+        unsafe {
+            let req = Request::from_ngx_http_request(request);
+            req.add_header_out("X-L402-Dry-Run", "1");
+            req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+        }
+    }
+
+    NGX_DECLINED as isize
+}
+
+fn dry_run_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("FATAL: failed to create tokio runtime: {}", e);
+                std::process::abort();
+            }
+        }
+    })
+}
+
+/// Minimal JSON-string escaper. Handles the bytes mandated by RFC 8259.
+/// Good enough for a single log line; avoids pulling in a JSON crate on
+/// the hot path.
+fn escape_json(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                use core::fmt::Write;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Content-phase handler for `l402_metrics`. Serves the Prometheus text
+/// exposition format at the configured location (e.g. `/metrics`).
+///
+/// Only `GET` and `HEAD` are accepted; anything else returns `405`.
+pub unsafe extern "C" fn l402_metrics_content_handler(r: *mut ngx_http_request_t) -> ngx_int_t {
+    // SAFETY: nginx passes a non-null, valid request pointer to content
+    // phase handlers for the lifetime of the call.
+    let r_ref = unsafe { &mut *r };
+
+    let method = r_ref.method as u32;
+    if method & (NGX_HTTP_GET | NGX_HTTP_HEAD) == 0 {
+        return NGX_HTTP_NOT_ALLOWED as ngx_int_t;
+    }
+
+    let rc = unsafe { ngx_http_discard_request_body(r) };
+    if rc != NGX_OK as ngx_int_t {
+        return rc;
+    }
+
+    let body = metrics::render();
+    let body_len = body.len();
+
+    // SAFETY: `r` is valid; `Request::from_ngx_http_request` just wraps the
+    // pointer, `pool()` returns a Pool tied to the request lifetime.
+    let req = unsafe { Request::from_ngx_http_request(r) };
+    let mut pool = req.pool();
+
+    let Some(mut buf) = pool.create_buffer_from_str(&body) else {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    };
+    buf.set_last_buf(true);
+    buf.set_last_in_chain(true);
+
+    let chain = pool.alloc_type::<ngx_chain_t>();
+    if chain.is_null() {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    }
+    // SAFETY: `chain` was allocated above from the request pool.
+    unsafe {
+        (*chain).buf = buf.as_ngx_buf_mut();
+        (*chain).next = std::ptr::null_mut();
+    }
+
+    req.set_status(HTTPStatus::OK);
+    req.set_content_length_n(body_len);
+    let _ = req.add_header_out("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+
+    let status = req.send_header();
+    if status.0 == NGX_ERROR as ngx_int_t || status.0 > NGX_OK as ngx_int_t || req.header_only() {
+        return status.0;
+    }
+
+    // SAFETY: `chain` is non-null, was just initialised, and lives for the
+    // request via the request pool.
+    unsafe { req.output_filter(&mut *chain).0 }
+}
+
+pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf`, `conf`, and `(*cf).args` are guaranteed valid by Nginx
+    // during config-parsing callbacks. `args.add(1)` is safe because
+    // NGX_CONF_TAKE1 ensures exactly one argument is present.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        let args = (*(*cf).args).elts as *mut ngx_str_t;
+        let val = (*args.add(1)).to_str();
+
+        if val.eq_ignore_ascii_case("on") {
+            conf.dry_run = true;
+            info!("⚙️ l402_dry_run enabled (shadow mode — requests will pass through)");
+        } else if val.eq_ignore_ascii_case("off") {
+            conf.dry_run = false;
+        } else {
+            error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
+            return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+pub unsafe extern "C" fn ngx_http_l402_metrics_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    _conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf` is guaranteed valid by Nginx during config parsing.
+    // `ngx_http_conf_get_module_loc_conf` requires a valid module reference.
+    // `ngx_http_core_module` is a static global defined by nginx core.
+    unsafe {
+        let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
+        if clcf.is_null() {
+            return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
+        }
+        (*clcf).handler = Some(l402_metrics_content_handler);
+    }
+    info!("⚙️ l402_metrics endpoint registered");
+    std::ptr::null_mut()
 }
 
 pub unsafe extern "C" fn ngx_http_l402_set(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,8 +814,10 @@ pub struct ModuleConfig {
     invoice_rate_limit: Option<(u32, u64)>,
     auto_detect_payment: bool,
     // Shadow mode: evaluate pricing and generate challenges but never block
-    // the request. Used for safe production rollouts.
-    dry_run: bool,
+    // the request. Used for safe production rollouts. `None` means unset
+    // (inherit from parent scope); `Some(false)` explicitly turns it off and
+    // stops inheritance.
+    dry_run: Option<bool>,
 }
 
 pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 9] = [
@@ -956,8 +958,10 @@ impl Merge for ModuleConfig {
         if prev.auto_detect_payment {
             self.auto_detect_payment = true;
         }
-        if prev.dry_run && !self.dry_run {
-            self.dry_run = true;
+        // Standard "child wins if set" merge — `l402_dry_run off;` in an inner
+        // location overrides `l402_dry_run on;` on the outer scope.
+        if self.dry_run.is_none() {
+            self.dry_run = prev.dry_run;
         }
         Ok(())
     }
@@ -1039,7 +1043,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let lnurl_addr = conf.lnurl_addr.clone();
         let invoice_rate_limit = conf.invoice_rate_limit;
         let auto_detect_payment = conf.auto_detect_payment;
-        let dry_run = conf.dry_run;
+        let dry_run = conf.dry_run.unwrap_or(false);
 
         (
             auth_header,
@@ -1123,13 +1127,6 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         );
     }
 
-    match result {
-        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
-        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
-        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
-        _ => {}
-    }
-
     if dry_run {
         return handle_dry_run_passthrough(
             request,
@@ -1143,15 +1140,25 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             caveats,
             result,
             auth_present,
+            invoice_rate_limit,
         );
+    }
+
+    // Enforce-mode outcome counters. Deliberately skipped above for dry-run
+    // so shadow traffic doesn't pollute enforce-mode SLO dashboards.
+    match result {
+        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
+        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
+        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
+        _ => {}
     }
 
     // Only set L402 header if result is 402
     if result == 402 {
-        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
+                metrics::inc(&metrics::L402_RATE_LIMITED_TOTAL);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
@@ -1168,6 +1175,8 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 return 429;
             }
         }
+        // Only count as "issued" once we're past the rate-limit gate.
+        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
 
         let rt = get_handler_runtime();
 
@@ -1776,6 +1785,7 @@ fn handle_dry_run_passthrough(
     caveats: Vec<String>,
     result: isize,
     auth_present: bool,
+    invoice_rate_limit: Option<(u32, u64)>,
 ) -> isize {
     metrics::inc(&metrics::L402_DRY_RUN_REQUESTS_TOTAL);
     if final_amount > 0 {
@@ -1789,10 +1799,29 @@ fn handle_dry_run_passthrough(
         other if (100..600).contains(&other) => other as u16,
         _ => 0,
     };
+
+    // Check the invoice rate limiter when an invoice *would* be issued.
+    // Without this, dry-run mode can hit the LN backend harder than enforce
+    // mode — the opposite of what "safe rollout" should mean.
+    let client_ip = get_client_ip(request);
+    let rate_limited = if would_return == 402 {
+        match invoice_rate_limit {
+            Some((max_requests, window_secs)) => {
+                !check_invoice_rate_limit(&client_ip, request_path, max_requests, window_secs)
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
+
     match would_return {
         200 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_ALLOW_TOTAL),
         401 | 402 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_BLOCK_TOTAL),
         _ => {}
+    }
+    if rate_limited {
+        metrics::inc(&metrics::L402_DRY_RUN_RATE_LIMITED_TOTAL);
     }
 
     let auth_state = match (auth_present, result) {
@@ -1801,7 +1830,6 @@ fn handle_dry_run_passthrough(
         (true, _) => "invalid",
     };
 
-    let client_ip = get_client_ip(request);
     let backend = LN_BACKEND_LABEL
         .get()
         .map(String::as_str)
@@ -1810,7 +1838,7 @@ fn handle_dry_run_passthrough(
     // Structured JSON line — easy to pick out of nginx error_log with jq/grep
     // and forward to Loki / Splunk / Datadog.
     info!(
-        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status}}}",
+        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status},\"rate_limited\":{rl}}}",
         route = escape_json(request_path),
         price = final_amount,
         src = price_source,
@@ -1818,9 +1846,17 @@ fn handle_dry_run_passthrough(
         ip = escape_json(&client_ip),
         state = auth_state,
         status = would_return,
+        rl = rate_limited,
     );
 
-    if would_return == 402 {
+    // SAFETY: `request` is non-null and valid for this handler's lifetime,
+    // as guaranteed by nginx before invoking the access handler.
+    let req = unsafe { Request::from_ngx_http_request(request) };
+    req.add_header_out("X-L402-Dry-Run", "1");
+
+    if would_return == 402 && !rate_limited {
+        req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+
         let rt = dry_run_runtime();
         let header_result = rt.block_on(async {
             module
@@ -1830,15 +1866,8 @@ fn handle_dry_run_passthrough(
 
         match header_result {
             Some(header_value) => {
-                // SAFETY: `request` is non-null and valid for this handler's
-                // lifetime, as guaranteed by nginx before invoking the handler.
-                unsafe {
-                    let req = Request::from_ngx_http_request(request);
-                    req.add_header_out("WWW-Authenticate", &header_value);
-                    req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
-                    req.add_header_out("X-L402-Dry-Run", "1");
-                    req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
-                }
+                req.add_header_out("WWW-Authenticate", &header_value);
+                req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
             }
             None => {
                 metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
@@ -1850,15 +1879,23 @@ fn handle_dry_run_passthrough(
                 );
             }
         }
-    } else {
-        // Still advertise the mode via a cheap header so clients know
-        // this route would normally be paid.
-        unsafe {
-            let req = Request::from_ngx_http_request(request);
-            req.add_header_out("X-L402-Dry-Run", "1");
-            req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+    } else if would_return == 402 && rate_limited {
+        // Rate-limited: surface the signal without hitting the LN backend.
+        req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+        req.add_header_out("X-L402-Dry-Run-Rate-Limited", "1");
+        if let Some((_, window_secs)) = invoice_rate_limit {
+            req.add_header_out("X-L402-Dry-Run-Retry-After", &window_secs.to_string());
         }
+        ngx_log_error!(
+            NGX_LOG_WARN,
+            log_ref,
+            "[l402_dry_run] invoice rate limit exceeded for IP={} path={}",
+            client_ip,
+            request_path
+        );
     }
+    // `would_return` 200/401 fall through with just `X-L402-Dry-Run: 1`:
+    // no price leak on paid-valid, no challenge replay on bad token.
 
     NGX_DECLINED as isize
 }
@@ -1972,10 +2009,10 @@ pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
         let val = (*args.add(1)).to_str();
 
         if val.eq_ignore_ascii_case("on") {
-            conf.dry_run = true;
+            conf.dry_run = Some(true);
             info!("⚙️ l402_dry_run enabled (shadow mode — requests will pass through)");
         } else if val.eq_ignore_ascii_case("off") {
-            conf.dry_run = false;
+            conf.dry_run = Some(false);
         } else {
             error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
             return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
@@ -1996,6 +2033,14 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
         let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
         if clcf.is_null() {
             return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
+        }
+        // Refuse to silently clobber a content handler registered by another
+        // directive (e.g. `proxy_pass`, `return`, `alias` + `try_files`, etc.).
+        // Fail fast at `nginx -t` rather than surprise operators at runtime.
+        if (*clcf).handler.is_some() {
+            error!("l402_metrics: another content handler is already registered for this location");
+            return b"l402_metrics: conflicts with another content handler in this location\0"
+                .as_ptr() as *mut c_char;
         }
         (*clcf).handler = Some(l402_metrics_content_handler);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use std::ptr::addr_of;
 use std::sync::Arc;
 use std::sync::Once;
 use std::sync::OnceLock;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use tonic_openssl_lnd::lnrpc;
 
@@ -1857,24 +1857,47 @@ fn handle_dry_run_passthrough(
     if would_return == 402 && !rate_limited {
         req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
 
+        // Hard cap on the LN backend round-trip. Shadow mode must not add
+        // latency to upstream traffic: if the backend stalls we bail out,
+        // count a challenge error, and pass the request through without a
+        // challenge header.
+        const DRY_RUN_CHALLENGE_TIMEOUT: Duration = Duration::from_secs(5);
+
         let rt = dry_run_runtime();
         let header_result = rt.block_on(async {
-            module
-                .get_l402_header(caveats, final_amount, macaroon_timeout, final_lnurl_addr)
-                .await
+            tokio::time::timeout(
+                DRY_RUN_CHALLENGE_TIMEOUT,
+                module.get_l402_header(
+                    caveats,
+                    final_amount,
+                    macaroon_timeout,
+                    final_lnurl_addr,
+                ),
+            )
+            .await
         });
 
         match header_result {
-            Some(header_value) => {
+            Ok(Some(header_value)) => {
                 req.add_header_out("WWW-Authenticate", &header_value);
                 req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
             }
-            None => {
+            Ok(None) => {
                 metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
                     "[l402_dry_run] failed to synthesise challenge for {}",
+                    request_path
+                );
+            }
+            Err(_) => {
+                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                ngx_log_error!(
+                    NGX_LOG_WARN,
+                    log_ref,
+                    "[l402_dry_run] challenge synthesis timed out after {}s for {}",
+                    DRY_RUN_CHALLENGE_TIMEOUT.as_secs(),
                     request_path
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,21 @@ use l402_middleware::middleware::L402Middleware;
 use l402_middleware::{bolt12, cln, eclair, l402, lnclient, lnd, lnurl, macaroon_util, nwc, utils};
 use log::{debug, error, info, warn};
 use macaroon::Verifier;
+use ngx::core::Buffer;
 use ngx::ffi::{
-    nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_cycle_s, ngx_http_core_module,
-    ngx_http_handler_pt, ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE,
-    ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t, ngx_str_t, ngx_uint_t, NGX_CONF_TAKE1,
-    NGX_DECLINED, NGX_ERROR, NGX_HTTP_LOC_CONF, NGX_HTTP_MAIN_CONF, NGX_HTTP_MODULE,
-    NGX_HTTP_SRV_CONF, NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_WARN, NGX_OK,
+    nginx_version, ngx_array_push, ngx_chain_t, ngx_command_t, ngx_conf_t, ngx_cycle_s,
+    ngx_http_core_module, ngx_http_discard_request_body, ngx_http_handler_pt, ngx_http_module_t,
+    ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t,
+    ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_GET,
+    NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOC_CONF, NGX_HTTP_MAIN_CONF,
+    NGX_HTTP_MODULE, NGX_HTTP_NOT_ALLOWED, NGX_HTTP_SRV_CONF, NGX_LOG_ERR, NGX_LOG_INFO,
+    NGX_LOG_WARN, NGX_OK,
     NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::http::{ngx_http_conf_get_module_main_conf, HTTPModule, Merge, MergeConfigError, Request};
+use ngx::http::{
+    ngx_http_conf_get_module_loc_conf, ngx_http_conf_get_module_main_conf, HTTPModule, HTTPStatus,
+    Merge, MergeConfigError, Request,
+};
 use ngx::{ngx_log_error, ngx_null_command, ngx_string};
 use r2d2::Pool;
 use redis::Client as RedisClient;
@@ -32,6 +38,7 @@ use tonic_openssl_lnd::lnrpc;
 
 mod cashu;
 mod cashu_redemption_logger;
+mod metrics;
 mod payment_detector;
 
 static INIT: Once = Once::new();
@@ -96,6 +103,10 @@ fn get_cashu_token_ttl() -> u64 {
 static LNURL_CLIENT_CACHE: OnceLock<
     tokio::sync::RwLock<HashMap<String, Arc<tokio::sync::Mutex<dyn lnclient::LNClient + Send>>>>,
 > = OnceLock::new();
+
+/// Configured LN backend type (`LNURL`, `LND`, `NWC`, ...) captured once at
+/// init for use in structured dry-run log lines.
+static LN_BACKEND_LABEL: OnceLock<String> = OnceLock::new();
 
 /// Get or create a cached LNURL client for the given address
 /// This function is also used by cashu.rs for multi-tenant redemption
@@ -802,9 +813,12 @@ pub struct ModuleConfig {
     // None means rate limiting is disabled for this location.
     invoice_rate_limit: Option<(u32, u64)>,
     auto_detect_payment: bool,
+    // Shadow mode: evaluate pricing and generate challenges but never block
+    // the request. Used for safe production rollouts.
+    dry_run: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 7] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 9] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -849,6 +863,22 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 7] = [
         name: ngx_string!("l402_auto_detect_payment"),
         type_: (NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
         set: Some(ngx_http_l402_auto_detect_payment_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_dry_run"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
+        set: Some(ngx_http_l402_dry_run_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_metrics"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
+        set: Some(ngx_http_l402_metrics_set),
         conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
         offset: 0,
         post: std::ptr::null_mut(),
@@ -926,6 +956,9 @@ impl Merge for ModuleConfig {
         if prev.auto_detect_payment {
             self.auto_detect_payment = true;
         }
+        if prev.dry_run && !self.dry_run {
+            self.dry_run = true;
+        }
         Ok(())
     }
 }
@@ -955,6 +988,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         lnurl_addr,
         invoice_rate_limit,
         auto_detect_payment,
+        dry_run,
     ) = unsafe {
         // NOTE: `authorization` can be null — not every request carries the header.
         let auth_header = if !r.headers_in.authorization.is_null() {
@@ -1005,6 +1039,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let lnurl_addr = conf.lnurl_addr.clone();
         let invoice_rate_limit = conf.invoice_rate_limit;
         let auto_detect_payment = conf.auto_detect_payment;
+        let dry_run = conf.dry_run;
 
         (
             auth_header,
@@ -1015,6 +1050,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             lnurl_addr,
             invoice_rate_limit,
             auto_detect_payment,
+            dry_run,
         )
     };
 
@@ -1043,7 +1079,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         None => true,
     };
 
-    let (final_amount, final_lnurl_addr) = if needs_dynamic_config {
+    let (final_amount, final_lnurl_addr, price_source) = if needs_dynamic_config {
         let redis_start = Instant::now();
         let (dynamic_amount, dynamic_lnurl) = module.get_dynamic_config(&request_path);
         if perf_log_enabled() {
@@ -1053,23 +1089,27 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 request_path
             );
         }
-        let amount = if dynamic_amount > 0 {
-            dynamic_amount
+        let (amount, src) = if dynamic_amount > 0 {
+            (dynamic_amount, "dynamic")
         } else {
-            amount_msat
+            (amount_msat, "static")
         };
-        (amount, dynamic_lnurl.or(lnurl_addr))
+        (amount, dynamic_lnurl.or(lnurl_addr), src)
     } else {
-        (amount_msat, lnurl_addr)
+        // L402 macaroon path skips the Redis lookup entirely — there is no
+        // dynamic price to compare against, so the source is "static".
+        (amount_msat, lnurl_addr, "static")
     };
 
+    metrics::inc(&metrics::L402_REQUESTS_TOTAL);
+    let auth_present = auth_header.is_some();
     let auth_start = Instant::now();
     let result = l402_access_handler(
         auth_header,
         uri,
         method,
         final_amount,
-        caveats,
+        caveats.clone(),
         final_lnurl_addr.clone(),
         auto_detect_payment,
     );
@@ -1083,8 +1123,32 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         );
     }
 
+    match result {
+        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
+        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
+        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
+        _ => {}
+    }
+
+    if dry_run {
+        return handle_dry_run_passthrough(
+            request,
+            log_ref,
+            module,
+            &request_path,
+            final_amount,
+            price_source,
+            final_lnurl_addr,
+            macaroon_timeout,
+            caveats,
+            result,
+            auth_present,
+        );
+    }
+
     // Only set L402 header if result is 402
     if result == 402 {
+        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
@@ -1491,6 +1555,11 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
 
     payment_detector::init_payment_detector();
 
+    // Cache the LN backend type string for structured log lines. We can't
+    // read env vars from worker threads, so snapshot it here.
+    let _ = LN_BACKEND_LABEL
+        .set(std::env::var("LN_CLIENT_TYPE").unwrap_or_else(|_| "LNURL".to_string()));
+
     // Check if Cashu eCash support is enabled
     let cashu_ecash_support_var =
         std::env::var("CASHU_ECASH_SUPPORT").unwrap_or_else(|_| "false".to_string());
@@ -1683,6 +1752,255 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
             });
     }
     0
+}
+
+/// Handle dry-run (shadow) mode: evaluate everything, log + increment metrics,
+/// but never block the request. Always returns [`NGX_DECLINED`] so nginx
+/// continues to the next phase and the upstream response is served as 200.
+///
+/// A synthesised L402 challenge is attached via the `WWW-Authenticate` *and*
+/// `X-L402-Dry-Run-Challenge` response headers so operators can inspect the
+/// challenge that *would* have been issued without parsing logs. Failure to
+/// generate the challenge (e.g. LN backend unreachable) is counted but does
+/// not fail the request.
+#[allow(clippy::too_many_arguments)]
+fn handle_dry_run_passthrough(
+    request: *mut ngx_http_request_t,
+    log_ref: *mut ngx_log_s,
+    module: &L402Module,
+    request_path: &str,
+    final_amount: i64,
+    price_source: &'static str,
+    final_lnurl_addr: Option<String>,
+    macaroon_timeout: i64,
+    caveats: Vec<String>,
+    result: isize,
+    auth_present: bool,
+) -> isize {
+    metrics::inc(&metrics::L402_DRY_RUN_REQUESTS_TOTAL);
+    if final_amount > 0 {
+        metrics::add(&metrics::L402_DRY_RUN_PRICE_MSAT_SUM, final_amount as u64);
+    }
+
+    let would_return: u16 = match result {
+        r if r == NGX_DECLINED as isize => 200,
+        401 => 401,
+        402 => 402,
+        other if (100..600).contains(&other) => other as u16,
+        _ => 0,
+    };
+    match would_return {
+        200 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_ALLOW_TOTAL),
+        401 | 402 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_BLOCK_TOTAL),
+        _ => {}
+    }
+
+    let auth_state = match (auth_present, result) {
+        (false, _) => "missing",
+        (true, r) if r == NGX_DECLINED as isize => "valid",
+        (true, _) => "invalid",
+    };
+
+    let client_ip = get_client_ip(request);
+    let backend = LN_BACKEND_LABEL
+        .get()
+        .map(String::as_str)
+        .unwrap_or("unknown");
+
+    // Structured JSON line — easy to pick out of nginx error_log with jq/grep
+    // and forward to Loki / Splunk / Datadog.
+    info!(
+        "{{\"event\":\"l402_dry_run\",\"route\":\"{route}\",\"price_msat\":{price},\"price_source\":\"{src}\",\"backend\":\"{backend}\",\"client_ip\":\"{ip}\",\"auth_state\":\"{state}\",\"would_return\":{status}}}",
+        route = escape_json(request_path),
+        price = final_amount,
+        src = price_source,
+        backend = backend,
+        ip = escape_json(&client_ip),
+        state = auth_state,
+        status = would_return,
+    );
+
+    if would_return == 402 {
+        let rt = dry_run_runtime();
+        let header_result = rt.block_on(async {
+            module
+                .get_l402_header(caveats, final_amount, macaroon_timeout, final_lnurl_addr)
+                .await
+        });
+
+        match header_result {
+            Some(header_value) => {
+                // SAFETY: `request` is non-null and valid for this handler's
+                // lifetime, as guaranteed by nginx before invoking the handler.
+                unsafe {
+                    let req = Request::from_ngx_http_request(request);
+                    req.add_header_out("WWW-Authenticate", &header_value);
+                    req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
+                    req.add_header_out("X-L402-Dry-Run", "1");
+                    req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+                }
+            }
+            None => {
+                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                ngx_log_error!(
+                    NGX_LOG_WARN,
+                    log_ref,
+                    "[l402_dry_run] failed to synthesise challenge for {}",
+                    request_path
+                );
+            }
+        }
+    } else {
+        // Still advertise the mode via a cheap header so clients know
+        // this route would normally be paid.
+        unsafe {
+            let req = Request::from_ngx_http_request(request);
+            req.add_header_out("X-L402-Dry-Run", "1");
+            req.add_header_out("X-L402-Dry-Run-Price-Msat", &final_amount.to_string());
+        }
+    }
+
+    NGX_DECLINED as isize
+}
+
+fn dry_run_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                eprintln!("FATAL: failed to create tokio runtime: {}", e);
+                std::process::abort();
+            }
+        }
+    })
+}
+
+/// Minimal JSON-string escaper. Handles the bytes mandated by RFC 8259.
+/// Good enough for a single log line; avoids pulling in a JSON crate on
+/// the hot path.
+fn escape_json(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                use core::fmt::Write;
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Content-phase handler for `l402_metrics`. Serves the Prometheus text
+/// exposition format at the configured location (e.g. `/metrics`).
+///
+/// Only `GET` and `HEAD` are accepted; anything else returns `405`.
+pub unsafe extern "C" fn l402_metrics_content_handler(r: *mut ngx_http_request_t) -> ngx_int_t {
+    // SAFETY: nginx passes a non-null, valid request pointer to content
+    // phase handlers for the lifetime of the call.
+    let r_ref = unsafe { &mut *r };
+
+    let method = r_ref.method as u32;
+    if method & (NGX_HTTP_GET | NGX_HTTP_HEAD) == 0 {
+        return NGX_HTTP_NOT_ALLOWED as ngx_int_t;
+    }
+
+    let rc = unsafe { ngx_http_discard_request_body(r) };
+    if rc != NGX_OK as ngx_int_t {
+        return rc;
+    }
+
+    let body = metrics::render();
+    let body_len = body.len();
+
+    // SAFETY: `r` is valid; `Request::from_ngx_http_request` just wraps the
+    // pointer, `pool()` returns a Pool tied to the request lifetime.
+    let req = unsafe { Request::from_ngx_http_request(r) };
+    let mut pool = req.pool();
+
+    let Some(mut buf) = pool.create_buffer_from_str(&body) else {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    };
+    buf.set_last_buf(true);
+    buf.set_last_in_chain(true);
+
+    let chain = pool.alloc_type::<ngx_chain_t>();
+    if chain.is_null() {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    }
+    // SAFETY: `chain` was allocated above from the request pool.
+    unsafe {
+        (*chain).buf = buf.as_ngx_buf_mut();
+        (*chain).next = std::ptr::null_mut();
+    }
+
+    req.set_status(HTTPStatus::OK);
+    req.set_content_length_n(body_len);
+    let _ = req.add_header_out("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+
+    let status = req.send_header();
+    if status.0 == NGX_ERROR as ngx_int_t || status.0 > NGX_OK as ngx_int_t || req.header_only() {
+        return status.0;
+    }
+
+    // SAFETY: `chain` is non-null, was just initialised, and lives for the
+    // request via the request pool.
+    unsafe { req.output_filter(&mut *chain).0 }
+}
+
+pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf`, `conf`, and `(*cf).args` are guaranteed valid by Nginx
+    // during config-parsing callbacks. `args.add(1)` is safe because
+    // NGX_CONF_TAKE1 ensures exactly one argument is present.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        let args = (*(*cf).args).elts as *mut ngx_str_t;
+        let val = (*args.add(1)).to_str();
+
+        if val.eq_ignore_ascii_case("on") {
+            conf.dry_run = true;
+            info!("⚙️ l402_dry_run enabled (shadow mode — requests will pass through)");
+        } else if val.eq_ignore_ascii_case("off") {
+            conf.dry_run = false;
+        } else {
+            error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
+            return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+pub unsafe extern "C" fn ngx_http_l402_metrics_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    _conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf` is guaranteed valid by Nginx during config parsing.
+    // `ngx_http_conf_get_module_loc_conf` requires a valid module reference.
+    // `ngx_http_core_module` is a static global defined by nginx core.
+    unsafe {
+        let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
+        if clcf.is_null() {
+            return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
+        }
+        (*clcf).handler = Some(l402_metrics_content_handler);
+    }
+    info!("⚙️ l402_metrics endpoint registered");
+    std::ptr::null_mut()
 }
 
 pub unsafe extern "C" fn ngx_http_l402_set(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -74,7 +74,7 @@ pub fn add(c: &AtomicU64, n: u64) {
 
 /// Render all counters in Prometheus text exposition format (version 0.0.4).
 pub fn render() -> String {
-    const ENTRIES: &[(&str, &str, &AtomicU64)] = &[
+    static ENTRIES: &[(&str, &str, &AtomicU64)] = &[
         (
             "l402_requests_total",
             "Total L402-protected requests seen by the access handler.",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,7 +6,7 @@
 //!
 //! No label dimensions are used — per-route or per-backend granularity is
 //! intentionally left to the structured JSON log line emitted for each
-//! dry-run request (see [`crate::log_dry_run_event`]).
+//! dry-run request (see `handle_dry_run_passthrough` in `lib.rs`).
 
 use core::fmt::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -37,6 +37,9 @@ counters! {
     /// Requests that arrived without an Authorization header.
     L402_PAYMENTS_MISSING_TOTAL,
 
+    /// Requests rejected with 429 by `l402_invoice_rate_limit` (enforce mode).
+    L402_RATE_LIMITED_TOTAL,
+
     /// Total requests handled in dry-run (shadow) mode.
     L402_DRY_RUN_REQUESTS_TOTAL,
 
@@ -49,6 +52,10 @@ counters! {
 
     /// Dry-run requests where challenge synthesis (invoice generation) failed.
     L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
+
+    /// Dry-run requests that would have been rejected with 429 by the
+    /// invoice rate limiter had enforcement been on.
+    L402_DRY_RUN_RATE_LIMITED_TOTAL,
 
     /// Sum of msat prices evaluated for dry-run requests. Divide by
     /// `l402_dry_run_requests_total` for an average-price gauge.
@@ -94,6 +101,11 @@ pub fn render() -> String {
             &L402_PAYMENTS_MISSING_TOTAL,
         ),
         (
+            "l402_rate_limited_total",
+            "Requests rejected with 429 by l402_invoice_rate_limit.",
+            &L402_RATE_LIMITED_TOTAL,
+        ),
+        (
             "l402_dry_run_requests_total",
             "Requests handled in dry-run (shadow) mode.",
             &L402_DRY_RUN_REQUESTS_TOTAL,
@@ -112,6 +124,11 @@ pub fn render() -> String {
             "l402_dry_run_challenge_errors_total",
             "Dry-run requests where L402 challenge synthesis failed.",
             &L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
+        ),
+        (
+            "l402_dry_run_rate_limited_total",
+            "Dry-run requests that would have been rate-limited in enforce mode.",
+            &L402_DRY_RUN_RATE_LIMITED_TOTAL,
         ),
         (
             "l402_dry_run_price_msat_sum",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,131 @@
+//! Prometheus-format counters for ngx_l402.
+//!
+//! Counters are global [`AtomicU64`]s updated from the access handler on the
+//! hot path; exposition format is rendered lazily via [`render`] when an
+//! operator scrapes the `l402_metrics` endpoint.
+//!
+//! No label dimensions are used — per-route or per-backend granularity is
+//! intentionally left to the structured JSON log line emitted for each
+//! dry-run request (see [`crate::log_dry_run_event`]).
+
+use core::fmt::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+macro_rules! counters {
+    ($($(#[$attr:meta])* $name:ident),* $(,)?) => {
+        $(
+            $(#[$attr])*
+            pub static $name: AtomicU64 = AtomicU64::new(0);
+        )*
+    };
+}
+
+counters! {
+    /// Every request that entered the L402 access handler with `l402 on;`,
+    /// regardless of whether enforcement was active.
+    L402_REQUESTS_TOTAL,
+
+    /// Requests that resulted in a 402 Payment Required response (enforced mode).
+    L402_CHALLENGES_ISSUED_TOTAL,
+
+    /// Requests whose Authorization header verified successfully.
+    L402_PAYMENTS_VALID_TOTAL,
+
+    /// Requests whose Authorization header failed verification (401).
+    L402_PAYMENTS_INVALID_TOTAL,
+
+    /// Requests that arrived without an Authorization header.
+    L402_PAYMENTS_MISSING_TOTAL,
+
+    /// Total requests handled in dry-run (shadow) mode.
+    L402_DRY_RUN_REQUESTS_TOTAL,
+
+    /// Dry-run requests that *would* have been blocked (401 or 402) in
+    /// enforce mode.
+    L402_DRY_RUN_WOULD_BLOCK_TOTAL,
+
+    /// Dry-run requests that *would* have been allowed through (valid token).
+    L402_DRY_RUN_WOULD_ALLOW_TOTAL,
+
+    /// Dry-run requests where challenge synthesis (invoice generation) failed.
+    L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
+
+    /// Sum of msat prices evaluated for dry-run requests. Divide by
+    /// `l402_dry_run_requests_total` for an average-price gauge.
+    L402_DRY_RUN_PRICE_MSAT_SUM,
+}
+
+#[inline]
+pub fn inc(c: &AtomicU64) {
+    c.fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline]
+pub fn add(c: &AtomicU64, n: u64) {
+    c.fetch_add(n, Ordering::Relaxed);
+}
+
+/// Render all counters in Prometheus text exposition format (version 0.0.4).
+pub fn render() -> String {
+    const ENTRIES: &[(&str, &str, &AtomicU64)] = &[
+        (
+            "l402_requests_total",
+            "Total L402-protected requests seen by the access handler.",
+            &L402_REQUESTS_TOTAL,
+        ),
+        (
+            "l402_challenges_issued_total",
+            "L402 challenges returned to clients (HTTP 402 in enforce mode).",
+            &L402_CHALLENGES_ISSUED_TOTAL,
+        ),
+        (
+            "l402_payments_valid_total",
+            "Authorization headers that verified successfully.",
+            &L402_PAYMENTS_VALID_TOTAL,
+        ),
+        (
+            "l402_payments_invalid_total",
+            "Authorization headers that failed verification.",
+            &L402_PAYMENTS_INVALID_TOTAL,
+        ),
+        (
+            "l402_payments_missing_total",
+            "Requests without an Authorization header.",
+            &L402_PAYMENTS_MISSING_TOTAL,
+        ),
+        (
+            "l402_dry_run_requests_total",
+            "Requests handled in dry-run (shadow) mode.",
+            &L402_DRY_RUN_REQUESTS_TOTAL,
+        ),
+        (
+            "l402_dry_run_would_block_total",
+            "Dry-run requests that would have been blocked in enforce mode.",
+            &L402_DRY_RUN_WOULD_BLOCK_TOTAL,
+        ),
+        (
+            "l402_dry_run_would_allow_total",
+            "Dry-run requests that would have been allowed through in enforce mode.",
+            &L402_DRY_RUN_WOULD_ALLOW_TOTAL,
+        ),
+        (
+            "l402_dry_run_challenge_errors_total",
+            "Dry-run requests where L402 challenge synthesis failed.",
+            &L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
+        ),
+        (
+            "l402_dry_run_price_msat_sum",
+            "Cumulative msat price evaluated across dry-run requests.",
+            &L402_DRY_RUN_PRICE_MSAT_SUM,
+        ),
+    ];
+
+    let mut out = String::with_capacity(ENTRIES.len() * 128);
+    for (name, help, counter) in ENTRIES {
+        // writeln! into String is infallible; ignore Result without unwrap.
+        let _ = writeln!(out, "# HELP {} {}", name, help);
+        let _ = writeln!(out, "# TYPE {} counter", name);
+        let _ = writeln!(out, "{} {}", name, counter.load(Ordering::Relaxed));
+    }
+    out
+}


### PR DESCRIPTION
## What
This PR adds a dry-run (shadow) mode for `ngx_l402` so operators can evaluate real pricing/auth behavior in production traffic without enforcing payment. It also adds a Prometheus metrics endpoint and docs for rollout/observability.

## Why
Rolling out L402 directly in enforce mode is risky: operators currently have no safe way to validate pricing logic, backend behavior, or charging patterns before users start getting blocked (`401/402`) or challenged.

Shadow mode enables a safer rollout path:
- evaluate full logic on live traffic
- emit logs/metrics for visibility
- pass requests through without payment enforcement

## How
### Core behavior
- Added `l402_dry_run on|off;` directive.
- In dry-run mode, requests still go through pricing + auth evaluation, but the module never enforces.
- Dry-run path returns `NGX_DECLINED` so nginx continues normal upstream handling.

### Dry-run observability
- Added structured dry-run log event with fields like:
  - route
  - price
  - price source (static/dynamic)
  - backend type
  - client IP
  - auth state
  - would-return status
  - rate-limited flag
- Added dry-run response headers for operator visibility:
  - `X-L402-Dry-Run`
  - `X-L402-Dry-Run-Price-Msat` (only when appropriate)
  - `X-L402-Dry-Run-Challenge` (when challenge synthesis succeeds)
  - rate-limit headers for dry-run rate-limited cases

### Metrics
- Added `l402_metrics;` directive to expose Prometheus metrics.
- Added counters for:
  - overall requests
  - enforce-mode outcomes
  - dry-run outcomes (`would_allow`, `would_block`, challenge errors, etc.)
  - dry-run price sum
- Added integration test coverage for `/shadow` + `/metrics`.

### Docs/config
- Added `docs/dry-run.md`
- Linked it from `README.md` and `docs/SUMMARY.md`
- Added sample `/shadow` and `/metrics` locations in `nginx.conf`

## Please note
Prometheus counters in this PR use process-local `static AtomicU64`s, so in a multi-worker nginx setup each worker tracks its own totals.

That means `/metrics` reflects worker-local counters (not fully aggregated across workers) for now.

I intentionally kept shared-memory aggregation out of this PR to keep review scope manageable and focused on shipping dry-run behavior safely. A follow-up PR can move counters into an nginx shared-memory zone for cross-worker aggregation.

## Testing
- [x] Manually tested dry-run behavior (`/shadow`) and metrics endpoint (`/metrics`)
- [x] Integration test added/updated in CI workflow (`tests.yml`)

## Checklist
- [x] Code formatted and linted
- [x] No breaking changes (feature is opt-in via directive)
- [x] Documentation updated

Closes #100