### PR TITLE
feat: add per-method payment and invoice metrics (#58)

### DIFF
--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -150,9 +150,13 @@ scrape_configs:
 | `l402_requests_total` | Every request that entered the access handler with `l402 on;`. Incremented for both enforce and shadow traffic. |
 | `l402_challenges_issued_total` | Requests that received a `402` response (enforce mode), counted *after* the rate-limit gate. |
 | `l402_rate_limited_total` | Requests rejected with `429` by `l402_invoice_rate_limit` (enforce mode). |
-| `l402_payments_valid_total` | Authorization headers that verified successfully (enforce mode only — dry-run traffic goes to `l402_dry_run_*`). |
+| `l402_payments_valid_total` | Authorization headers that verified successfully — Lightning + Cashu (enforce mode only — dry-run traffic goes to `l402_dry_run_*`). |
+| `l402_payments_lightning_total` | Successful payments settled via a Lightning macaroon (classic preimage *or* auto-detect). |
+| `l402_payments_cashu_total` | Successful payments settled via a Cashu token redemption. |
 | `l402_payments_invalid_total` | Authorization headers that failed verification (enforce mode only). |
 | `l402_payments_missing_total` | Requests without an Authorization header (enforce mode only). |
+| `l402_invoices_generated_total` | Lightning invoices successfully generated for L402 challenges (enforce mode only). |
+| `l402_invoices_generation_errors_total` | Failures generating a Lightning invoice during challenge synthesis (returns `500`). |
 | `l402_dry_run_requests_total` | Requests handled in shadow mode. |
 | `l402_dry_run_would_block_total` | Shadow-mode requests that *would* have been blocked (`401` or `402`). |
 | `l402_dry_run_would_allow_total` | Shadow-mode requests that *would* have been allowed (`200`). |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,6 +1256,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
 
         match header_result {
             Some(header_value) => unsafe {
+                metrics::inc(&metrics::L402_INVOICES_GENERATED_TOTAL);
                 ngx_log_error!(
                     NGX_LOG_INFO,
                     log_ref,
@@ -1265,6 +1266,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 req.add_header_out("WWW-Authenticate", &header_value);
             },
             None => {
+                metrics::inc(&metrics::L402_INVOICES_GENERATION_ERRORS_TOTAL);
                 ngx_log_error!(NGX_LOG_ERR, log_ref, "Failed to get L402 header");
                 return 500; // Return server error if we couldn't get the header
             }
@@ -1322,6 +1324,7 @@ pub fn l402_access_handler(
 
             match verify_result {
                 Ok(true) => {
+                    metrics::inc(&metrics::L402_PAYMENTS_CASHU_TOTAL);
                     return NGX_DECLINED as isize;
                 }
                 Ok(false) => {
@@ -1459,6 +1462,7 @@ pub fn l402_access_handler(
                 ) {
                     Ok(_) => {
                         info!("✅ L402 auto-detect verification successful");
+                        metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL);
                         if let Err(e) = store_preimage_as_used(&preimage_bytes) {
                             error!("⚠️ Failed to store preimage in Redis: {}", e);
                         }
@@ -1519,6 +1523,7 @@ pub fn l402_access_handler(
                     ) {
                         Ok(_) => {
                             info!("✅ L402 verification successful");
+                            metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL);
                             // Atomic claim. Real replays are filtered by the
                             // pre-check above, so Ok(false) here only happens
                             // for benign concurrent races between workers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1125,6 +1125,22 @@ unsafe fn send_html_response(r: *mut ngx_http_request_t, status: u16, body: Stri
 }
 
 
+// Per-worker scratch slot used by `l402_access_handler` to report *which*
+// payment method satisfied a successful verification. The wrapper consumes it
+// only in enforce mode (after the dry-run early return) so shadow traffic
+// doesn't pollute `l402_payments_lightning_total` / `l402_payments_cashu_total`
+// and the invariant `valid = lightning + cashu` holds.
+#[derive(Clone, Copy)]
+enum PaymentMethod {
+    Lightning,
+    Cashu,
+}
+
+thread_local! {
+    static LAST_PAYMENT_METHOD: std::cell::Cell<Option<PaymentMethod>> =
+        const { std::cell::Cell::new(None) };
+}
+
 // SAFETY: This function is an Nginx access-phase handler registered via
 // `postconfiguration`. Nginx guarantees that `request`, `request->connection`,
 // `request->connection->log`, and `request->loc_conf` are valid, non-null
@@ -1309,9 +1325,23 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     }
 
     // Enforce-mode outcome counters. Deliberately skipped above for dry-run
-    // so shadow traffic doesn't pollute enforce-mode SLO dashboards.
+    // so shadow traffic doesn't pollute enforce-mode SLO dashboards. The
+    // per-method counters are consumed from the thread-local set by
+    // `l402_access_handler` so the invariant `valid = lightning + cashu`
+    // holds and shadow traffic never ticks them.
     match result {
-        r if r == NGX_DECLINED as isize => metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL),
+        r if r == NGX_DECLINED as isize => {
+            metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL);
+            match LAST_PAYMENT_METHOD.with(|m| m.take()) {
+                Some(PaymentMethod::Lightning) => {
+                    metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL)
+                }
+                Some(PaymentMethod::Cashu) => {
+                    metrics::inc(&metrics::L402_PAYMENTS_CASHU_TOTAL)
+                }
+                None => {}
+            }
+        }
         401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
         402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
         _ => {}
@@ -1491,6 +1521,9 @@ pub fn l402_access_handler(
     lnurl_addr: Option<String>,
     auto_detect_payment: bool,
 ) -> isize {
+    // Reset so the wrapper never reads a stale method from a prior request.
+    LAST_PAYMENT_METHOD.with(|m| m.set(None));
+
     let module = match unsafe { MODULE.as_ref() } {
         Some(m) => m,
         None => {
@@ -1521,7 +1554,7 @@ pub fn l402_access_handler(
 
             match verify_result {
                 Ok(true) => {
-                    metrics::inc(&metrics::L402_PAYMENTS_CASHU_TOTAL);
+                    LAST_PAYMENT_METHOD.with(|m| m.set(Some(PaymentMethod::Cashu)));
                     return NGX_DECLINED as isize;
                 }
                 Ok(false) => {
@@ -1667,7 +1700,7 @@ pub fn l402_access_handler(
                 ) {
                     Ok(_) => {
                         info!("✅ L402 auto-detect verification successful");
-                        metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL);
+                        LAST_PAYMENT_METHOD.with(|m| m.set(Some(PaymentMethod::Lightning)));
                         if let Err(e) = store_preimage_as_used(&preimage_bytes) {
                             error!("⚠️ Failed to store preimage in Redis: {}", e);
                         }
@@ -1734,7 +1767,7 @@ pub fn l402_access_handler(
                     ) {
                         Ok(_) => {
                             info!("✅ L402 verification successful");
-                            metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL);
+                            LAST_PAYMENT_METHOD.with(|m| m.set(Some(PaymentMethod::Lightning)));
                             // Atomic claim. Real replays are filtered by the
                             // pre-check above, so Ok(false) here only happens
                             // for benign concurrent races between workers

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -29,13 +29,29 @@ counters! {
     L402_CHALLENGES_ISSUED_TOTAL,
 
     /// Requests whose Authorization header verified successfully.
+    /// Aggregate of [`L402_PAYMENTS_LIGHTNING_TOTAL`] and
+    /// [`L402_PAYMENTS_CASHU_TOTAL`].
     L402_PAYMENTS_VALID_TOTAL,
+
+    /// Successful payments settled via a Lightning macaroon (classic preimage
+    /// path *or* auto-detect path).
+    L402_PAYMENTS_LIGHTNING_TOTAL,
+
+    /// Successful payments settled via a Cashu token redemption.
+    L402_PAYMENTS_CASHU_TOTAL,
 
     /// Requests whose Authorization header failed verification (401).
     L402_PAYMENTS_INVALID_TOTAL,
 
     /// Requests that arrived without an Authorization header.
     L402_PAYMENTS_MISSING_TOTAL,
+
+    /// Lightning invoices successfully generated as part of a 402 challenge.
+    L402_INVOICES_GENERATED_TOTAL,
+
+    /// Lightning invoice generation failures (LN backend unreachable, LNURL
+    /// errors, etc.) that resulted in a 500 response.
+    L402_INVOICES_GENERATION_ERRORS_TOTAL,
 
     /// Requests rejected with 429 by `l402_invoice_rate_limit` (enforce mode).
     L402_RATE_LIMITED_TOTAL,
@@ -87,8 +103,18 @@ pub fn render() -> String {
         ),
         (
             "l402_payments_valid_total",
-            "Authorization headers that verified successfully.",
+            "Authorization headers that verified successfully (Lightning + Cashu).",
             &L402_PAYMENTS_VALID_TOTAL,
+        ),
+        (
+            "l402_payments_lightning_total",
+            "Successful payments settled via a Lightning macaroon.",
+            &L402_PAYMENTS_LIGHTNING_TOTAL,
+        ),
+        (
+            "l402_payments_cashu_total",
+            "Successful payments settled via a Cashu token redemption.",
+            &L402_PAYMENTS_CASHU_TOTAL,
         ),
         (
             "l402_payments_invalid_total",
@@ -99,6 +125,16 @@ pub fn render() -> String {
             "l402_payments_missing_total",
             "Requests without an Authorization header.",
             &L402_PAYMENTS_MISSING_TOTAL,
+        ),
+        (
+            "l402_invoices_generated_total",
+            "Lightning invoices successfully generated for L402 challenges.",
+            &L402_INVOICES_GENERATED_TOTAL,
+        ),
+        (
+            "l402_invoices_generation_errors_total",
+            "Failures generating a Lightning invoice during L402 challenge synthesis.",
+            &L402_INVOICES_GENERATION_ERRORS_TOTAL,
         ),
         (
             "l402_rate_limited_total",


### PR DESCRIPTION
Closes #58.

<img width="1331" height="831" alt="image" src="https://github.com/user-attachments/assets/283ef27c-37c8-4c20-85c0-dfca78d8486d" />

## Summary

Adds four Prometheus counters so operators can answer the questions the issue raises:

| Counter | What it tracks |
|---|---|
| `l402_payments_lightning_total` | Successful Lightning macaroon verifications (classic preimage + auto-detect paths) |
| `l402_payments_cashu_total` | Successful Cashu token redemptions |
| `l402_invoices_generated_total` | Lightning invoices successfully generated for L402 challenges |
| `l402_invoices_generation_errors_total` | LN-backend failures during challenge synthesis (returns 500) |

The existing `l402_payments_valid_total` is preserved as the aggregate (= `lightning_total + cashu_total`), so existing dashboards keep working. The issue's `l402_failed_payments` is already covered by `l402_payments_invalid_total`.

## Mapping to issue requests

| Issue asked for | This PR exposes |
|---|---|
| `l402_payments_total` | `l402_payments_valid_total` (existing) |
| `l402_cashu_payments_total` | `l402_payments_cashu_total` (new) |
| `l402_failed_payments` | `l402_payments_invalid_total` (existing) |
| `l402_invoice_generated_total` | `l402_invoices_generated_total` (new) |

## Verification

Built the image and ran `nginx-lnurl` with `worker_processes 1` to consolidate counters in one process, then drove a known traffic mix:

- 3 × no-auth → 402
- 5 × bogus L402 → 401
- 1 × valid L402 → 200
- 2 × bogus Cashu → 401

Final scrape:
```
l402_requests_total 11
l402_challenges_issued_total 3
l402_payments_valid_total 1
l402_payments_lightning_total 1     # ← new
l402_payments_cashu_total 0         # ← new
l402_payments_invalid_total 7
l402_payments_missing_total 3
l402_invoices_generated_total 3     # ← new
l402_invoices_generation_errors_total 0   # ← new
```

Every count matches the expected request mix and the aggregate invariant `valid = lightning + cashu` holds.

## Out of scope

The issue comment mentions "look up payments by invoice / refund support" — that's a larger feature (new endpoint + persistent payment store) and is better tracked separately.

## Note on per-worker counters

This is pre-existing behaviour, but worth flagging: nginx forks workers, so the `AtomicU64` statics in `metrics.rs` are per-worker. With `worker_processes auto;` (default), each scrape returns whichever worker handled `/metrics`. Prometheus rate queries still work directionally but absolute counts are per-process. Cross-worker aggregation (shared memory zone or Redis) would be a follow-up if exact totals matter.

## Test plan

- [x] `cargo check` passes (no new warnings)
- [x] Manual end-to-end via `nginx-lnurl` container — counters increment as expected
- [ ] CI integration tests pass (existing `/metrics` test still expects the original counter names — should still pass since none were renamed)