### PR TITLE
feat: .well-known/l402 capability manifest (#106)

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,169 @@
+# Capability Manifest
+
+The `l402_manifest` directive turns a location into a discovery endpoint
+that emits a JSON description of every L402-protected route on the
+server. It is intended to live at `/.well-known/l402` ([RFC 8615][well-known]),
+making this instance self-describing to clients that have only the host.
+
+```nginx
+location = /.well-known/l402 {
+    l402_manifest;
+
+    # Optional: restrict who can scrape pricing details.
+    # allow 10.0.0.0/8;
+    # deny  all;
+}
+```
+
+This is the agent-era equivalent of `robots.txt` or `security.txt`. An
+autonomous agent (or any client) given only `https://example.com` can
+fetch the manifest, learn which routes are paid, how much they cost, and
+which payment backends are accepted — without any out-of-band integration.
+
+---
+
+## Example response
+
+```json
+{
+  "version": "1",
+  "service": {
+    "name": "Example API",
+    "description": "Stock data API"
+  },
+  "payment_methods": [
+    {
+      "type": "lightning",
+      "backend": "LNURL",
+      "address": "hello@getalby.com"
+    },
+    {
+      "type": "cashu",
+      "mints": ["https://mint.minibits.cash"],
+      "p2pk_supported": true,
+      "challenge_header": "X-Cashu"
+    }
+  ],
+  "routes": [
+    {
+      "path": "/protected",
+      "price": {
+        "type": "static",
+        "amount_msat": 10000
+      },
+      "caveats_required": ["RequestPath = /protected"]
+    },
+    {
+      "path": "/rate-limited",
+      "price": {
+        "type": "static",
+        "amount_msat": 10000
+      },
+      "caveats_required": ["RequestPath = /rate-limited"],
+      "rate_limit": {
+        "max_requests": 2,
+        "window_secs": 60
+      }
+    }
+  ]
+}
+```
+
+---
+
+## What the manifest describes
+
+| Field | Source | Meaning |
+|---|---|---|
+| `version` | constant `"1"` | Schema version. Bumped on breaking changes; agents should reject unknown majors. |
+| `service.name`, `service.description`, `service.operator`, `service.contact` | env vars `L402_SERVICE_NAME`, `L402_SERVICE_DESCRIPTION`, `L402_SERVICE_OPERATOR`, `L402_SERVICE_CONTACT` | Optional, omitted when unset. |
+| `payment_methods[].type` | `lightning` or `cashu` | Which payment rail this method describes. |
+| `payment_methods[].backend` | env var `LN_CLIENT_TYPE` | `LNURL`, `LND`, `CLN`, `NWC`, `BOLT12`, `ECLAIR`, `LNC`. |
+| `payment_methods[].address` | env var `LNURL_ADDRESS` (LNURL backends only) | Server-default LN address. May be overridden per-route via `lnurl_addr`. |
+| `payment_methods[].mints` | env var `CASHU_WHITELISTED_MINTS` | Allowed Cashu mints (when Cashu is enabled). |
+| `payment_methods[].p2pk_supported` | env var `CASHU_P2PK_MODE` | Whether NUT-24 P2PK Cashu is enabled. |
+| `routes[].path` | `location` directive | URL path served by this route. |
+| `routes[].price.amount_msat` | `l402_amount_msat_default` | Base price after `merge_loc_conf`. |
+| `routes[].caveats_required` | derived | Caveats the issued macaroon will carry. Today always `[RequestPath = <path>]`. |
+| `routes[].macaroon_timeout_secs` | `l402_macaroon_timeout` | Omitted when `0` (no expiry). |
+| `routes[].lnurl_addr` | `l402_lnurl_addr` | Per-route LNURL override for multi-tenant deployments. |
+| `routes[].rate_limit` | `l402_invoice_rate_limit` | Server-side invoice rate limit applied before challenge issuance. |
+| `routes[].auto_detect_payment` | `l402_auto_detect_payment` | When true, clients can omit the preimage and the server settles via node lookup. |
+
+Dynamic (Redis-backed) pricing is **not** reflected in `price.amount_msat` —
+the manifest emits the static default. Dynamic prices change per request
+and would require a Redis round-trip per route to render accurately;
+that's out of scope for v1.
+
+---
+
+## Hiding a route
+
+Operators may want certain paid routes to remain undiscoverable — private
+APIs, beta tiers, customer-specific endpoints. Use `l402_manifest_hide;`
+on the location:
+
+```nginx
+location /internal-paid {
+    l402 on;
+    l402_amount_msat_default 100000;
+    l402_manifest_hide;       # not advertised in /.well-known/l402
+}
+```
+
+The route still enforces L402 normally. It just doesn't appear in the
+manifest's `routes[]` array.
+
+---
+
+## Service-level metadata
+
+The optional `service` block is read from environment variables at
+manifest-render time:
+
+```sh
+L402_SERVICE_NAME="Example API"
+L402_SERVICE_DESCRIPTION="Premium financial data, paid per request."
+L402_SERVICE_OPERATOR="npub1abcd..."   # Nostr pubkey, DID, or free-form
+L402_SERVICE_CONTACT="ops@example.com"
+```
+
+All four are optional. Unset variables are omitted from the response so
+the manifest stays valid JSON even with no service metadata.
+
+---
+
+## Caveats and limitations
+
+- **Per-worker registry.** Like `l402_metrics`, the manifest registry is
+  per-nginx-worker. On a multi-worker deployment, every worker sees the
+  same routes (config is shared), so this is a non-issue for the manifest
+  itself.
+- **No authentication by default.** Pricing information is public.
+  Restrict the endpoint with `allow`/`deny`, an auth subrequest, or a
+  firewall if competitors should not see your full pricing matrix.
+- **Reload behaviour.** On `nginx -s reload`, new workers start with a
+  fresh registry built from the new config. Old workers serve in-flight
+  requests with their existing registry until they exit.
+
+---
+
+## Why this matters
+
+Without a manifest, every L402 integration is a bespoke wiring job: the
+client must be told the routes, prices, payment backends, and caveat
+formats out of band. With one, an agent can land on a host and onboard
+itself end-to-end:
+
+```text
+GET /.well-known/l402         → learn the API surface
+GET /protected                → receive 402 + bolt11 invoice
+PAY the invoice               → get preimage
+GET /protected with L402 auth → success
+```
+
+For autonomous agents — Claude tools, MCP servers, custom-built — this is
+the difference between L402 being a protocol and L402 being a
+*discoverable web standard*.
+
+[well-known]: https://datatracker.ietf.org/doc/html/rfc8615

--- a/nginx.conf
+++ b/nginx.conf
@@ -103,6 +103,13 @@ http {
             l402_metrics;
         }
 
+        # Capability manifest. Lets agents (and humans) discover this
+        # instance's paid routes, prices, and accepted payment backends
+        # via a single JSON document — the agent-era robots.txt.
+        location = /.well-known/l402 {
+            l402_manifest;
+        }
+
         # Rate-limited endpoint: only 2 invoices per minute per IP.
         # Used by the invoice rate limiting integration tests.
         location /rate-limited {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,37 @@ use tonic_openssl_lnd::lnrpc;
 
 mod cashu;
 mod cashu_redemption_logger;
+mod manifest;
 mod metrics;
 mod payment_detector;
 
 static INIT: Once = Once::new();
 static mut MODULE: Option<L402Module> = None;
+
+/// Registry of l402-enabled locations, populated at config-parse time and
+/// drained at `.well-known/l402` request time. Each entry holds the
+/// location's path and a raw pointer to its `ModuleConfig` — the config
+/// lives in nginx's cycle pool, so the pointer remains valid until the
+/// next reload, at which point a fresh worker process is started with a
+/// new registry.
+struct ConfPtr(*const ModuleConfig);
+// SAFETY: the ModuleConfig pointers are written once during single-threaded
+// config-parse and read-only afterwards. nginx's cycle pool guarantees the
+// pointee outlives the registry. There is no aliasing with mutable access.
+unsafe impl Send for ConfPtr {}
+unsafe impl Sync for ConfPtr {}
+
+struct RouteRegistration {
+    path: String,
+    conf: ConfPtr,
+}
+
+static MANIFEST_REGISTRY: OnceLock<std::sync::Mutex<Vec<RouteRegistration>>> = OnceLock::new();
+
+fn manifest_registry() -> &'static std::sync::Mutex<Vec<RouteRegistration>> {
+    MANIFEST_REGISTRY.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
 /// Connection pool for Redis. Checked out connections are returned automatically on drop.
 /// Pool size is configurable via REDIS_POOL_SIZE (default: cpu_count * 3, min 5, max 50).
 static REDIS_POOL: OnceLock<Pool<RedisClient>> = OnceLock::new();
@@ -787,6 +813,18 @@ impl HTTPModule for L402Module {
     type SrvConf = ();
     type LocConf = ModuleConfig;
 
+    unsafe extern "C" fn preconfiguration(_cf: *mut ngx_conf_t) -> ngx_int_t {
+        // Clear the manifest registry at the start of each config parse.
+        // On `nginx -s reload`, the master parses the new config; without
+        // this clear we'd accumulate stale (path, conf_ptr) entries from
+        // the previous cycle whose pool memory has been freed — reading
+        // them later from /.well-known/l402 is a use-after-free.
+        if let Ok(mut reg) = manifest_registry().lock() {
+            reg.clear();
+        }
+        NGX_OK as ngx_int_t
+    }
+
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
         info!("🚀 Initializing L402 module handler");
         let cmcf = ngx_http_conf_get_module_main_conf(cf, &*addr_of!(ngx_http_core_module));
@@ -818,9 +856,13 @@ pub struct ModuleConfig {
     // (inherit from parent scope); `Some(false)` explicitly turns it off and
     // stops inheritance.
     dry_run: Option<bool>,
+    // When set via `l402_manifest_hide;`, this route is excluded from the
+    // `.well-known/l402` capability manifest. The route is still gated as
+    // normal — this just makes it not discoverable.
+    manifest_hidden: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 9] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 11] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -881,6 +923,22 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 9] = [
         name: ngx_string!("l402_metrics"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
         set: Some(ngx_http_l402_metrics_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_manifest"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
+        set: Some(ngx_http_l402_manifest_set),
+        conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_manifest_hide"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
+        set: Some(ngx_http_l402_manifest_hide_set),
         conf: NGX_RS_HTTP_LOC_CONF_OFFSET,
         offset: 0,
         post: std::ptr::null_mut(),
@@ -962,6 +1020,9 @@ impl Merge for ModuleConfig {
         // location overrides `l402_dry_run on;` on the outer scope.
         if self.dry_run.is_none() {
             self.dry_run = prev.dry_run;
+        }
+        if prev.manifest_hidden {
+            self.manifest_hidden = true;
         }
         Ok(())
     }
@@ -1563,6 +1624,7 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     ngx_log_error!(NGX_LOG_INFO, log, "Starting module initialization");
 
     payment_detector::init_payment_detector();
+    manifest::init_env_snapshot();
 
     // Cache the LN backend type string for structured log lines. We can't
     // read env vars from worker threads, so snapshot it here.
@@ -2071,6 +2133,135 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
     std::ptr::null_mut()
 }
 
+pub unsafe extern "C" fn ngx_http_l402_manifest_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    _conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: same guarantees as `ngx_http_l402_metrics_set` above.
+    unsafe {
+        let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
+        if clcf.is_null() {
+            return b"l402_manifest: missing core loc conf\0".as_ptr() as *mut c_char;
+        }
+        if (*clcf).handler.is_some() {
+            error!(
+                "l402_manifest: another content handler is already registered for this location"
+            );
+            return b"l402_manifest: conflicts with another content handler in this location\0"
+                .as_ptr() as *mut c_char;
+        }
+        (*clcf).handler = Some(l402_manifest_content_handler);
+    }
+    info!("⚙️ l402_manifest endpoint registered (.well-known/l402 capability manifest)");
+    std::ptr::null_mut()
+}
+
+pub unsafe extern "C" fn ngx_http_l402_manifest_hide_set(
+    _cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `conf` points to this location's ModuleConfig, guaranteed
+    // valid by nginx during directive parsing.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        conf.manifest_hidden = true;
+    }
+    info!("⚙️ l402_manifest_hide: excluding this route from /.well-known/l402");
+    std::ptr::null_mut()
+}
+
+/// Content-phase handler for `l402_manifest`. Serves the
+/// `.well-known/l402` capability manifest as JSON.
+///
+/// Only `GET` and `HEAD` are accepted; anything else returns `405`. The
+/// manifest is rebuilt on every request — cheap because the registry is
+/// in-process and small (one entry per l402-protected location).
+pub unsafe extern "C" fn l402_manifest_content_handler(r: *mut ngx_http_request_t) -> ngx_int_t {
+    let r_ref = unsafe { &mut *r };
+
+    let method = r_ref.method as u32;
+    if method & (NGX_HTTP_GET | NGX_HTTP_HEAD) == 0 {
+        return NGX_HTTP_NOT_ALLOWED as ngx_int_t;
+    }
+
+    let rc = unsafe { ngx_http_discard_request_body(r) };
+    if rc != NGX_OK as ngx_int_t {
+        return rc;
+    }
+
+    let snapshots = collect_route_snapshots();
+    let body = manifest::render(&snapshots);
+    let body_len = body.len();
+
+    let req = unsafe { Request::from_ngx_http_request(r) };
+    let mut pool = req.pool();
+
+    let Some(mut buf) = pool.create_buffer_from_str(&body) else {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    };
+    buf.set_last_buf(true);
+    buf.set_last_in_chain(true);
+
+    let chain = pool.alloc_type::<ngx_chain_t>();
+    if chain.is_null() {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR as ngx_int_t;
+    }
+    // SAFETY: `chain` was just allocated from the request pool.
+    unsafe {
+        (*chain).buf = buf.as_ngx_buf_mut();
+        (*chain).next = std::ptr::null_mut();
+    }
+
+    req.set_status(HTTPStatus::OK);
+    req.set_content_length_n(body_len);
+    let _ = req.add_header_out("Content-Type", "application/json; charset=utf-8");
+
+    let status = req.send_header();
+    if status.0 == NGX_ERROR as ngx_int_t || status.0 > NGX_OK as ngx_int_t || req.header_only() {
+        return status.0;
+    }
+
+    // SAFETY: `chain` is non-null, initialised, and lives for the request
+    // via the request pool.
+    unsafe { req.output_filter(&mut *chain).0 }
+}
+
+/// Read each registered route's `ModuleConfig` and build a snapshot. Called
+/// at request time so post-merge values (amount_msat, rate_limit, …) are
+/// reflected.
+fn collect_route_snapshots() -> Vec<manifest::RouteSnapshot> {
+    let Ok(registry) = manifest_registry().lock() else {
+        return Vec::new();
+    };
+    registry
+        .iter()
+        .filter_map(|entry| {
+            if entry.conf.0.is_null() {
+                return None;
+            }
+            // SAFETY: the pointer was captured during config parse; the
+            // pointee lives in nginx's cycle pool for the lifetime of the
+            // worker process. No mutable aliasing — we hold a shared ref.
+            let conf = unsafe { &*entry.conf.0 };
+            if !conf.enable {
+                // `l402 off;` in a child location overrides a parent `on`.
+                return None;
+            }
+            Some(manifest::RouteSnapshot {
+                path: entry.path.clone(),
+                price_msat: conf.amount_msat,
+                macaroon_timeout: conf.macaroon_timeout,
+                lnurl_addr: conf.lnurl_addr.clone(),
+                rate_limit: conf.invoice_rate_limit,
+                auto_detect_payment: conf.auto_detect_payment,
+                hidden: conf.manifest_hidden,
+            })
+        })
+        .collect()
+}
+
 pub unsafe extern "C" fn ngx_http_l402_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2080,7 +2271,8 @@ pub unsafe extern "C" fn ngx_http_l402_set(
     // during config-parsing callbacks. `args.add(1)` is safe because
     // NGX_CONF_TAKE1 ensures exactly one argument is present.
     unsafe {
-        let conf = &mut *(conf as *mut ModuleConfig);
+        let conf_ptr = conf as *mut ModuleConfig;
+        let conf = &mut *conf_ptr;
         let args = (*(*cf).args).elts as *mut ngx_str_t;
 
         let val = (*args.add(1)).to_str().trim().to_lowercase();
@@ -2089,6 +2281,25 @@ pub unsafe extern "C" fn ngx_http_l402_set(
             "on" | "true" | "1" | "yes" => {
                 conf.enable = true;
                 info!("⚙️ Enabled L402 for this location");
+                // Snapshot the location's path now and remember the conf
+                // pointer; the `.well-known/l402` handler re-reads the conf
+                // at request time so post-merge values (amount_msat, etc.)
+                // are picked up correctly.
+                if let Some(path) = location_name_str(cf) {
+                    if let Ok(mut reg) = manifest_registry().lock() {
+                        // Skip dup entries — `l402 on;` could appear more
+                        // than once in pathological configs.
+                        if !reg
+                            .iter()
+                            .any(|r| r.path == path && r.conf.0 == conf_ptr)
+                        {
+                            reg.push(RouteRegistration {
+                                path,
+                                conf: ConfPtr(conf_ptr),
+                            });
+                        }
+                    }
+                }
             }
             "off" | "false" | "0" | "no" => {
                 conf.enable = false;
@@ -2101,6 +2312,22 @@ pub unsafe extern "C" fn ngx_http_l402_set(
     };
 
     std::ptr::null_mut()
+}
+
+/// Read the current location's name (path) from the core loc conf during
+/// directive parsing. Returns `None` if nginx hasn't populated `name` yet
+/// (e.g. directive used outside a `location` block).
+unsafe fn location_name_str(cf: *mut ngx_conf_t) -> Option<String> {
+    let clcf = ngx_http_conf_get_module_loc_conf(cf, &*addr_of!(ngx_http_core_module));
+    if clcf.is_null() {
+        return None;
+    }
+    let name: ngx_str_t = (*clcf).name;
+    if name.len == 0 || name.data.is_null() {
+        return None;
+    }
+    let slice = std::slice::from_raw_parts(name.data, name.len);
+    Some(String::from_utf8_lossy(slice).into_owned())
 }
 
 pub unsafe extern "C" fn ngx_http_l402_amount_set(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,213 @@
+//! `.well-known/l402` capability manifest.
+//!
+//! Renders a machine-readable JSON description of every L402-protected
+//! location in the running configuration, so agents (and humans) can
+//! discover an instance's pricing, accepted payment backends, and route
+//! semantics without out-of-band configuration.
+//!
+//! Decoupled from `ModuleConfig` on purpose: the caller in `lib.rs` walks
+//! the per-location configs (which it owns), builds a vector of
+//! [`RouteSnapshot`], and hands it here for rendering. Keeps this module
+//! free of nginx-FFI internals and trivially unit-testable.
+
+use serde_json::{json, Value};
+use std::env;
+use std::sync::OnceLock;
+
+/// Cached snapshot of env-driven manifest fields. Populated by
+/// [`init_env_snapshot`] from the master process (where env vars are
+/// readable) and read at render time from any worker — nginx clears env
+/// vars on `fork()` so workers can't query them directly.
+#[derive(Debug, Default)]
+struct EnvSnapshot {
+    service_name: Option<String>,
+    service_description: Option<String>,
+    service_operator: Option<String>,
+    service_contact: Option<String>,
+    ln_client_type: String,
+    lnurl_address: Option<String>,
+    cashu_enabled: bool,
+    cashu_mints: Vec<String>,
+    cashu_p2pk: bool,
+}
+
+static ENV_SNAPSHOT: OnceLock<EnvSnapshot> = OnceLock::new();
+
+/// Cache env-driven manifest fields once, at module init in the master
+/// process. Safe to call multiple times — second and later calls are
+/// no-ops via [`OnceLock`].
+pub fn init_env_snapshot() {
+    let _ = ENV_SNAPSHOT.set(EnvSnapshot {
+        service_name: env::var("L402_SERVICE_NAME").ok().filter(|s| !s.is_empty()),
+        service_description: env::var("L402_SERVICE_DESCRIPTION")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        service_operator: env::var("L402_SERVICE_OPERATOR")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        service_contact: env::var("L402_SERVICE_CONTACT")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        ln_client_type: env::var("LN_CLIENT_TYPE")
+            .unwrap_or_else(|_| "LNURL".to_string())
+            .to_uppercase(),
+        lnurl_address: env::var("LNURL_ADDRESS").ok().filter(|s| !s.is_empty()),
+        cashu_enabled: env::var("CASHU_ECASH_SUPPORT")
+            .map(|v| v.trim().eq_ignore_ascii_case("true"))
+            .unwrap_or(false),
+        cashu_mints: env::var("CASHU_WHITELISTED_MINTS")
+            .map(|v| {
+                v.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        cashu_p2pk: env::var("CASHU_P2PK_MODE")
+            .map(|v| v.trim().eq_ignore_ascii_case("true"))
+            .unwrap_or(false),
+    });
+}
+
+fn env_snapshot() -> &'static EnvSnapshot {
+    // Lazy fallback: if init_env_snapshot was never called (shouldn't
+    // happen in production, but keeps unit-test-style usage sane),
+    // populate from whatever env is visible right now.
+    ENV_SNAPSHOT.get_or_init(EnvSnapshot::default)
+}
+
+/// Snapshot of a single l402-protected location, taken at manifest-render
+/// time (after all `merge_loc_conf` passes have completed).
+#[derive(Clone, Debug)]
+pub struct RouteSnapshot {
+    pub path: String,
+    pub price_msat: i64,
+    pub macaroon_timeout: i64,
+    pub lnurl_addr: Option<String>,
+    /// `(max_requests, window_secs)` from `l402_invoice_rate_limit`.
+    pub rate_limit: Option<(u32, u64)>,
+    pub auto_detect_payment: bool,
+    /// True when the operator marked this route with `l402_manifest_hide;` —
+    /// exclude from the rendered manifest.
+    pub hidden: bool,
+}
+
+/// Render the full manifest as a pretty-printed JSON string.
+///
+/// `routes` is the post-merge snapshot of every location with `l402 on;`.
+/// Hidden routes are filtered out here so callers don't have to remember.
+pub fn render(routes: &[RouteSnapshot]) -> String {
+    let visible: Vec<&RouteSnapshot> = routes.iter().filter(|r| !r.hidden).collect();
+
+    let manifest = json!({
+        "version": "1",
+        "service": service_block(),
+        "payment_methods": payment_methods_block(),
+        "routes": visible.iter().map(|r| route_block(r)).collect::<Vec<_>>(),
+    });
+
+    // `to_string_pretty` is infallible for `serde_json::Value`; the result
+    // is JSON we built, not user input.
+    serde_json::to_string_pretty(&manifest).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn service_block() -> Value {
+    // Service-level metadata is opt-in via env vars. Operators who don't
+    // set them get an empty object — the manifest is still valid JSON.
+    let snap = env_snapshot();
+    let mut block = serde_json::Map::new();
+    if let Some(name) = &snap.service_name {
+        block.insert("name".to_string(), json!(name));
+    }
+    if let Some(desc) = &snap.service_description {
+        block.insert("description".to_string(), json!(desc));
+    }
+    if let Some(operator) = &snap.service_operator {
+        block.insert("operator".to_string(), json!(operator));
+    }
+    if let Some(contact) = &snap.service_contact {
+        block.insert("contact".to_string(), json!(contact));
+    }
+    Value::Object(block)
+}
+
+fn payment_methods_block() -> Value {
+    let snap = env_snapshot();
+    let mut methods: Vec<Value> = Vec::new();
+
+    let mut lightning = serde_json::Map::new();
+    lightning.insert("type".to_string(), json!("lightning"));
+    lightning.insert("backend".to_string(), json!(snap.ln_client_type));
+    if snap.ln_client_type.eq_ignore_ascii_case("LNURL") {
+        if let Some(addr) = &snap.lnurl_address {
+            lightning.insert("address".to_string(), json!(addr));
+        }
+    }
+    methods.push(Value::Object(lightning));
+
+    if snap.cashu_enabled {
+        let mut cashu = serde_json::Map::new();
+        cashu.insert("type".to_string(), json!("cashu"));
+        if !snap.cashu_mints.is_empty() {
+            cashu.insert("mints".to_string(), json!(snap.cashu_mints));
+        }
+        if snap.cashu_p2pk {
+            cashu.insert("p2pk_supported".to_string(), json!(true));
+            cashu.insert("challenge_header".to_string(), json!("X-Cashu"));
+        }
+        methods.push(Value::Object(cashu));
+    }
+
+    Value::Array(methods)
+}
+
+fn route_block(r: &RouteSnapshot) -> Value {
+    let mut block = serde_json::Map::new();
+    block.insert("path".to_string(), json!(r.path));
+
+    // Price: only emit `static` for now. Dynamic pricing (Redis-backed)
+    // is per-key, not knowable at manifest-render time without a redis
+    // round-trip per route — out of scope for v1 of the manifest.
+    let mut price = serde_json::Map::new();
+    price.insert("type".to_string(), json!("static"));
+    price.insert("amount_msat".to_string(), json!(r.price_msat));
+    block.insert("price".to_string(), Value::Object(price));
+
+    // Caveats the macaroon will carry. Today the access handler binds
+    // `RequestPath = <path>` on every challenge; surfacing it here lets
+    // agents pre-validate their L402 client logic.
+    block.insert(
+        "caveats_required".to_string(),
+        json!([format!("RequestPath = {}", r.path)]),
+    );
+
+    if r.macaroon_timeout > 0 {
+        block.insert(
+            "macaroon_timeout_secs".to_string(),
+            json!(r.macaroon_timeout),
+        );
+    }
+
+    if let Some(addr) = &r.lnurl_addr {
+        // Per-route LNURL override (multi-tenant config). Top-level
+        // `payment_methods` reflects the server default; this overrides it.
+        block.insert("lnurl_addr".to_string(), json!(addr));
+    }
+
+    if let Some((max_requests, window_secs)) = r.rate_limit {
+        block.insert(
+            "rate_limit".to_string(),
+            json!({
+                "max_requests": max_requests,
+                "window_secs": window_secs,
+            }),
+        );
+    }
+
+    if r.auto_detect_payment {
+        block.insert("auto_detect_payment".to_string(), json!(true));
+    }
+
+    Value::Object(block)
+}
+


### PR DESCRIPTION
Closes #106.

## Summary

Adds a `l402_manifest` directive that serves a JSON capability manifest at `/.well-known/l402` describing every L402-protected route on the server — the agent-era equivalent of `robots.txt`.

Without this, every L402 integration is a bespoke wiring job: clients have to be told the routes, prices, accepted payment backends, and caveat formats out of band. With it, an autonomous agent given only a hostname can fetch the manifest, learn the API surface, and start paying with no prior integration.

## What the manifest contains

- **Top level:** schema `version`, optional `service` block (name / description / operator / contact), `payment_methods` array (Lightning backend + Cashu config), and a `routes` array.
- **Per route:** path, static price in msat, required caveats, optional `macaroon_timeout_secs`, optional per-route `lnurl_addr` override (multi-tenant), optional `rate_limit`, optional `auto_detect_payment` flag.

Full example response and field-by-field source table in [`docs/manifest.md`](./docs/manifest.md).

## New directives

```nginx
location = /.well-known/l402 {
    l402_manifest;          # serve the JSON manifest here
}

location /internal-paid {
    l402 on;
    l402_amount_msat_default 100000;
    l402_manifest_hide;     # still enforced, but not advertised
}
```

## Verification

Built the image and ran `nginx-lnurl` against `nginx.conf` (eight l402-protected locations including multi-tenant LNURL, rate limit, auto-detect, shadow mode, and macaroon-timeout variants):

```text
GET /.well-known/l402 → 200, application/json
{
  "version": "1",
  "service": { "name": "...", "description": "...", "operator": "...", "contact": "..." },
  "payment_methods": [
    { "type": "lightning", "backend": "LNURL", "address": "hello@getalby.com" },
    { "type": "cashu", "mints": [...] }
  ],
  "routes": [
    { "path": "/protected",         "price": { "type": "static", "amount_msat": 10000 }, ... },
    { "path": "/protected-timeout", "macaroon_timeout_secs": 15, ... },
    { "path": "/rate-limited",      "rate_limit": { "max_requests": 2, "window_secs": 60 }, ... },
    { "path": "/protected-auto",    "auto_detect_payment": true, ... },
    { "path": "/tenant1",           "lnurl_addr": "hello@getalby.com", ... },
    { "path": "/tenant2",           "lnurl_addr": "bumi@getalby.com", ... },
    ...
  ]
}
```

Every per-location field surfaces correctly: macaroon timeouts, rate limits, auto-detect, multi-tenant LNURL overrides. Non-regression confirmed: `/protected` still returns 402 with a valid challenge, `/metrics` still works, free route still returns 200.

**Reload behaviour:**
- Verified `nginx -s reload` after adding `l402_manifest_hide` to a route correctly drops it from the manifest.
- Verified 3× consecutive reloads keep the route count stable (no accumulation).
- Without the `preconfiguration` clear, the registry would accumulate dangling pointers into freed cycle pools — caught during testing as a use-after-free that returned garbage bytes; the clear fixes it.

**Hide directive:** `l402_manifest_hide;` keeps enforcement on but removes the route from the manifest's `routes[]`.

## Implementation notes

- **Registry**: `(path, *const ModuleConfig)` populated when `l402 on;` is parsed; pointer is read at request time so post-merge values (`amount_msat`, `rate_limit`, `lnurl_addr`, …) are reflected accurately.
- **Reload safety**: `preconfiguration` clears the registry, so a fresh parse starts clean. Old workers continue serving from their pre-fork state until they exit; no aliasing.
- **Env vars**: cached at `init_module` in the master process. Nginx zeroes the environment on worker `fork()` so reading at request time would return empty.
- **Decoupling**: `src/manifest.rs` knows nothing about nginx FFI or `ModuleConfig`; `lib.rs` snapshots configs into a `Vec<RouteSnapshot>` and hands it to `manifest::render`. Keeps the JSON renderer trivially testable on its own.

## Out of scope

- **Dynamic (Redis-backed) pricing surfaced as static.** Dynamic prices change per request and would require a Redis round-trip per route to render — left for a follow-up; see #106 open question 1.
- **Service info via directives** instead of env vars. Env vars were the smaller surface area for v1; a `l402_service_name "..."` directive can be added without breaking the schema.
- **Per-route descriptions.** No `description` field on routes yet — needs either a directive or a config-file convention. Worth a follow-up issue if operators want it.

## Test plan

- [x] `cargo check` passes (no new warnings beyond pre-existing `static_mut_refs`)
- [x] Manual end-to-end on `nginx-lnurl`: manifest emits all 8 routes with correct per-location fields
- [x] Hide directive removes routes
- [x] Reload safety (3× reload, route count stable, no use-after-free)
- [x] Service env vars populate the service block
- [x] Existing `/protected`, `/metrics`, free routes unaffected
- [ ] Integration test that scrapes `/.well-known/l402` and validates schema (good follow-up — would be cheap to add to `tests.yml`)