### PR TITLE
feat: bind L402 macaroons to HTTP method to prevent cross-method replay

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1115,7 +1115,7 @@ jobs:
             exit 1
           fi
 
-          # Test L402 method binding (issue #101): a token paid for one HTTP
+          # Test L402 method binding: a token paid for one HTTP
           # method must not be redeemable on a different method on the same
           # path. Uses a freshly-paid invoice so this case is independent of
           # the hardcoded preimage tested above.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1115,6 +1115,68 @@ jobs:
             exit 1
           fi
 
+          # Test L402 method binding (issue #101): a token paid for one HTTP
+          # method must not be redeemable on a different method on the same
+          # path. Uses a freshly-paid invoice so this case is independent of
+          # the hardcoded preimage tested above.
+          echo "Testing L402 method binding (RequestMethod caveat)..."
+          docker exec redis redis-cli flushall
+
+          method_resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 -X GET http://0.0.0.0:8000/protected)
+          method_status=$(echo "$method_resp" | tail -n1)
+          if [ "$method_status" -ne 402 ]; then
+            echo "Error: GET /protected (no auth) returned $method_status, expected 402"
+            echo "$method_resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
+
+          method_invoice=$(echo "$method_resp" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
+          method_macaroon=$(echo "$method_resp" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          if [ -z "$method_invoice" ] || [ -z "$method_macaroon" ]; then
+            echo "Error: missing invoice or macaroon in 402 response for method-binding test"
+            echo "$method_resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
+
+          echo "Paying method-binding invoice from lndnode..."
+          docker exec lndnode lncli -n regtest payinvoice -f "$method_invoice"
+          sleep 5
+          method_preimage=$(docker exec lndnode lncli -n regtest listpayments | jq -r '.payments[-1].payment_preimage')
+          if [ -z "$method_preimage" ] || [ "$method_preimage" = "null" ]; then
+            echo "Error: could not extract preimage from lndnode for method-binding test"
+            docker exec lndnode lncli -n regtest listpayments
+            exit 1
+          fi
+
+          # Cross-method replay: a GET-bound token used on POST must be rejected.
+          # Run this BEFORE the GET case so the preimage isn't yet stored as used
+          # by replay protection — we want to confirm the rejection comes from
+          # the method caveat, not from preimage reuse.
+          echo "POST /protected with GET-bound token (expect 401)..."
+          post_resp=$(curl -s -w "\n%{http_code}" --max-time 30 -X POST -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
+          post_status=$(echo "$post_resp" | tail -n1)
+          if [ "$post_status" -ne 401 ]; then
+            echo "Error: POST /protected with GET-bound token returned $post_status, expected 401 (cross-method replay must be rejected)"
+            echo "$post_resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
+          echo "PASS: cross-method replay rejected"
+
+          # Same token on the original method must still succeed.
+          echo "GET /protected with GET-bound token (expect 200)..."
+          get_resp=$(curl -s -w "\n%{http_code}" --max-time 30 -X GET -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
+          get_status=$(echo "$get_resp" | tail -n1)
+          if [ "$get_status" -ne 200 ]; then
+            echo "Error: GET /protected with GET-bound token returned $get_status, expected 200"
+            echo "$get_resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
+          echo "PASS: same-method redemption accepted"
+
           # Test LND Autodetect Payment
           echo "Testing LND Autodetect Payment..."
           response=$(curl -s -i -w "\n%{http_code}" --max-time 30 -L http://0.0.0.0:8000/protected-auto)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1150,16 +1150,19 @@ jobs:
             exit 1
           fi
 
-          # Cross-method replay: a GET-bound token used on POST must be rejected.
+          # Cross-method replay: a GET-bound token used on a different allowed
+          # method must be rejected. We use HEAD (not POST): this location uses
+          # try_files + static content, so nginx returns 405 for POST before
+          # the L402 handler runs — HEAD still reaches access phase like GET.
           # Run this BEFORE the GET case so the preimage isn't yet stored as used
           # by replay protection — we want to confirm the rejection comes from
           # the method caveat, not from preimage reuse.
-          echo "POST /protected with GET-bound token (expect 401)..."
-          post_resp=$(curl -s -w "\n%{http_code}" --max-time 30 -X POST -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
-          post_status=$(echo "$post_resp" | tail -n1)
-          if [ "$post_status" -ne 401 ]; then
-            echo "Error: POST /protected with GET-bound token returned $post_status, expected 401 (cross-method replay must be rejected)"
-            echo "$post_resp"
+          echo "HEAD /protected with GET-bound token (expect 401)..."
+          cross_method_resp=$(curl -s -w "\n%{http_code}" --max-time 30 -X HEAD -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
+          cross_method_status=$(echo "$cross_method_resp" | tail -n1)
+          if [ "$cross_method_status" -ne 401 ]; then
+            echo "Error: HEAD /protected with GET-bound token returned $cross_method_status, expected 401 (cross-method replay must be rejected)"
+            echo "$cross_method_resp"
             docker logs nginx-lnd
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1154,12 +1154,14 @@ jobs:
           # method must be rejected. We use HEAD (not POST): this location uses
           # try_files + static content, so nginx returns 405 for POST before
           # the L402 handler runs — HEAD still reaches access phase like GET.
+          # Use `curl -I` (libcurl proper HEAD) instead of `-X HEAD`; the latter
+          # makes curl wait for a body that never comes and hangs until timeout.
           # Run this BEFORE the GET case so the preimage isn't yet stored as used
           # by replay protection — we want to confirm the rejection comes from
           # the method caveat, not from preimage reuse.
           echo "HEAD /protected with GET-bound token (expect 401)..."
-          cross_method_resp=$(curl -s -w "\n%{http_code}" --max-time 30 -X HEAD -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
-          cross_method_status=$(echo "$cross_method_resp" | tail -n1)
+          cross_method_status=$(curl -o /dev/null -s -w "%{http_code}" --max-time 30 -I -H "Authorization: L402 $method_macaroon:$method_preimage" http://0.0.0.0:8000/protected)
+          cross_method_resp="(status only: $cross_method_status)"
           if [ "$cross_method_status" -ne 401 ]; then
             echo "Error: HEAD /protected with GET-bound token returned $cross_method_status, expected 401 (cross-method replay must be rejected)"
             echo "$cross_method_resp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1471,10 +1471,15 @@ pub fn l402_access_handler(
                             return current_time <= ts;
                         }
                     }
-                    // Reject any caveat the general checker doesn't understand;
-                    // caveats like RequestPath and RequestMethod must match the
-                    // current request via the exact set.
-                    false
+                    // `RequestMethod = …` must be satisfied by the exact set
+                    // (populated from the current request's method). Falling
+                    // through to `true` would let a GET-bound token verify
+                    // against a HEAD/POST/PUT/… request and defeat the
+                    // binding added for issue #101.
+                    if predicate_str.starts_with("RequestMethod = ") {
+                        return false;
+                    }
+                    true
                 });
                 for caveat in &caveats {
                     if !caveat.starts_with("ExpiresAt = ") {
@@ -1539,10 +1544,15 @@ pub fn l402_access_handler(
                                 return is_valid;
                             }
                         }
-                        // Reject any caveat the general checker doesn't understand;
-                        // caveats like RequestPath and RequestMethod must match the
-                        // current request via the exact set.
-                        false
+                        // `RequestMethod = …` must be satisfied by the exact
+                        // set (populated from the current request's method).
+                        // Falling through to `true` would let a GET-bound
+                        // token verify against a HEAD/POST/PUT/… request and
+                        // defeat the binding added for issue #101.
+                        if predicate_str.starts_with("RequestMethod = ") {
+                            return false;
+                        }
+                        true
                     });
 
                     // Add exact caveats, ignoring ExpiresAt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,13 @@ use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_chain_t, ngx_command_t, ngx_conf_t, ngx_cycle_s,
     ngx_http_core_module, ngx_http_discard_request_body, ngx_http_handler_pt, ngx_http_module_t,
     ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t,
-    ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_GET,
-    NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOC_CONF, NGX_HTTP_MAIN_CONF,
-    NGX_HTTP_MODULE, NGX_HTTP_NOT_ALLOWED, NGX_HTTP_SRV_CONF, NGX_LOG_ERR, NGX_LOG_INFO,
-    NGX_LOG_WARN, NGX_OK,
-    NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
+    ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_COPY,
+    NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK,
+    NGX_HTTP_LOC_CONF, NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE,
+    NGX_HTTP_NOT_ALLOWED, NGX_HTTP_OPTIONS, NGX_HTTP_PATCH, NGX_HTTP_POST, NGX_HTTP_PROPFIND,
+    NGX_HTTP_PROPPATCH, NGX_HTTP_PUT, NGX_HTTP_SRV_CONF, NGX_HTTP_TRACE, NGX_HTTP_UNLOCK,
+    NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_WARN, NGX_OK, NGX_RS_HTTP_LOC_CONF_OFFSET,
+    NGX_RS_MODULE_SIGNATURE,
 };
 use ngx::http::{
     ngx_http_conf_get_module_loc_conf, ngx_http_conf_get_module_main_conf, HTTPModule, HTTPStatus,
@@ -967,6 +969,32 @@ impl Merge for ModuleConfig {
     }
 }
 
+/// Map nginx's `r->method` bitmask to the canonical uppercase string used in
+/// the `RequestMethod` macaroon caveat. Falls back to `"UNKNOWN"` for methods
+/// nginx didn't recognise; both sides of the protocol see the same fallback,
+/// so the binding still excludes cross-method replay between recognised
+/// methods (the only ones a typical client will use).
+fn method_caveat_value(method: u32) -> &'static str {
+    match method {
+        m if m == NGX_HTTP_GET => "GET",
+        m if m == NGX_HTTP_HEAD => "HEAD",
+        m if m == NGX_HTTP_POST => "POST",
+        m if m == NGX_HTTP_PUT => "PUT",
+        m if m == NGX_HTTP_DELETE => "DELETE",
+        m if m == NGX_HTTP_OPTIONS => "OPTIONS",
+        m if m == NGX_HTTP_PATCH => "PATCH",
+        m if m == NGX_HTTP_TRACE => "TRACE",
+        m if m == NGX_HTTP_MKCOL => "MKCOL",
+        m if m == NGX_HTTP_COPY => "COPY",
+        m if m == NGX_HTTP_MOVE => "MOVE",
+        m if m == NGX_HTTP_PROPFIND => "PROPFIND",
+        m if m == NGX_HTTP_PROPPATCH => "PROPPATCH",
+        m if m == NGX_HTTP_LOCK => "LOCK",
+        m if m == NGX_HTTP_UNLOCK => "UNLOCK",
+        _ => "UNKNOWN",
+    }
+}
+
 // SAFETY: This function is an Nginx access-phase handler registered via
 // `postconfiguration`. Nginx guarantees that `request`, `request->connection`,
 // `request->connection->log`, and `request->loc_conf` are valid, non-null
@@ -1064,7 +1092,13 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             request_path = request_path[..pos].to_string();
         }
     }
-    let caveats = vec![format!("RequestPath = {}", request_path)];
+    // Bind the macaroon to both the normalized path and the HTTP method so a
+    // token paid for `GET /v1/data` can't be replayed against `POST /v1/data`.
+    let request_method = method_caveat_value(method);
+    let caveats = vec![
+        format!("RequestPath = {}", request_path),
+        format!("RequestMethod = {}", request_method),
+    ];
 
     let module = match unsafe { MODULE.as_ref() } {
         Some(m) => m,
@@ -1234,7 +1268,10 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let invoice_start = Instant::now();
         // Caveats were consumed by the access handler above; rebuild on the 402
         // path only — saves a Vec<String> clone on the auth-pass hot path.
-        let challenge_caveats = vec![format!("RequestPath = {}", request_path)];
+        let challenge_caveats = vec![
+            format!("RequestPath = {}", request_path),
+            format!("RequestMethod = {}", request_method),
+        ];
         let header_result = rt.block_on(async {
             module
                 .get_l402_header(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1471,7 +1471,10 @@ pub fn l402_access_handler(
                             return current_time <= ts;
                         }
                     }
-                    true
+                    // Reject any caveat the general checker doesn't understand;
+                    // caveats like RequestPath and RequestMethod must match the
+                    // current request via the exact set.
+                    false
                 });
                 for caveat in &caveats {
                     if !caveat.starts_with("ExpiresAt = ") {
@@ -1536,9 +1539,10 @@ pub fn l402_access_handler(
                                 return is_valid;
                             }
                         }
-                        // Return true for predicates we don't need to validate
-                        // This allows other predicates to pass through
-                        true
+                        // Reject any caveat the general checker doesn't understand;
+                        // caveats like RequestPath and RequestMethod must match the
+                        // current request via the exact set.
+                        false
                     });
 
                     // Add exact caveats, ignoring ExpiresAt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1474,8 +1474,8 @@ pub fn l402_access_handler(
                     // `RequestMethod = …` must be satisfied by the exact set
                     // (populated from the current request's method). Falling
                     // through to `true` would let a GET-bound token verify
-                    // against a HEAD/POST/PUT/… request and defeat the
-                    // binding added for issue #101.
+                    // against a HEAD/POST/PUT/… request and defeat HTTP method
+                    // binding on the macaroon.
                     if predicate_str.starts_with("RequestMethod = ") {
                         return false;
                     }
@@ -1548,7 +1548,7 @@ pub fn l402_access_handler(
                         // set (populated from the current request's method).
                         // Falling through to `true` would let a GET-bound
                         // token verify against a HEAD/POST/PUT/… request and
-                        // defeat the binding added for issue #101.
+                        // defeat HTTP method binding on the macaroon.
                         if predicate_str.starts_with("RequestMethod = ") {
                             return false;
                         }


### PR DESCRIPTION
## What
Bind every L402 macaroon to the HTTP method of the request that mints it (`RequestMethod = <verb>`), alongside the existing `RequestPath` caveat.

## Why
A token paid for `GET /v1/data` could be replayed against `POST /v1/data` on the same path. Each token should authorise exactly one (method, path) pair.

## How
- New `method_caveat_value()` maps nginx's `r->method` to the HTTP verb.
- Challenge issuance and the 402 rebuild now add `RequestMethod = <verb>`.
- Verification is unchanged: the existing loop feeds every caveat in the
  vec to `verifier.satisfy_exact`, so a mismatched method now fails the
  macaroon check.

## Testing
Integration test added in `.github/workflows/tests.yml`

Closes #101