### PR TITLE
fix: bound auto-detect Lightning lookup with 5s timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1483,23 +1483,36 @@ pub fn l402_access_handler(
 
                         match payment_detector::PAYMENT_DETECTOR.get() {
                             Some(detector) => {
+                                const AUTODETECT_LOOKUP_TIMEOUT: Duration =
+                                    Duration::from_secs(5);
                                 match rt.block_on(async {
-                                    detector.lookup_settled_invoice(&payment_hash).await
+                                    tokio::time::timeout(
+                                        AUTODETECT_LOOKUP_TIMEOUT,
+                                        detector.lookup_settled_invoice(&payment_hash),
+                                    )
+                                    .await
                                 }) {
-                                    Ok(Some(p)) => {
+                                    Ok(Ok(Some(p))) => {
                                         // Cache for future requests
                                         if let Err(e) = cache_settled_preimage(&payment_hash, &p) {
                                             warn!("⚠️ Failed to cache settled preimage: {}", e);
                                         }
                                         p
                                     }
-                                    Ok(None) => {
+                                    Ok(Ok(None)) => {
                                         info!("⏳ Invoice not yet settled — returning 402");
                                         return 402;
                                     }
-                                    Err(e) => {
+                                    Ok(Err(e)) => {
                                         error!("❌ Node invoice lookup failed: {}", e);
                                         return 500;
+                                    }
+                                    Err(_) => {
+                                        warn!(
+                                            "Auto-detect invoice lookup timed out after {}s — returning 402",
+                                            AUTODETECT_LOOKUP_TIMEOUT.as_secs()
+                                        );
+                                        return 402;
                                     }
                                 }
                             }


### PR DESCRIPTION
## What

Adds a 5 second timeout around the auto-detect Lightning invoice lookup in `l402_access_handler`. If the node does not respond in time, the worker returns 402 instead of blocking indefinitely.

## Why

With `l402_auto_detect_payment on`, requests that miss the Redis cache call `lookup_settled_invoice` inside `block_on` with no upper bound on how long that call can take. A slow or unreachable LND/CLN/Eclair node can tie up an nginx worker for a long time, and enough concurrent requests can exhaust the worker pool.

## How

Wraps `detector.lookup_settled_invoice(&payment_hash)` in `tokio::time::timeout` with a 5 second limit, using the same pattern as the dry-run challenge timeout elsewhere in `src/lib.rs`.

- Settled invoice found: unchanged
- Not settled: 402
- Lookup error: 500
- Timeout: 402 with a warning log

Only `src/lib.rs` is changed.

## Testing

- `cargo check` passes on `fix/auto-detect-lookup-timeout`
- Branch rebased onto current `upstream/main` and merges cleanly

## Checklist

- No breaking changes

Closes #109 