### PR TITLE
docs: rename .well-known/l402 → .well-known/l402-services

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -2,11 +2,11 @@
 
 The `l402_manifest` directive turns a location into a discovery endpoint
 that emits a JSON description of every L402-protected route on the
-server. It is intended to live at `/.well-known/l402` ([RFC 8615][well-known]),
+server. It is intended to live at `/.well-known/l402-services` ([RFC 8615][well-known]),
 making this instance self-describing to clients that have only the host.
 
 ```nginx
-location = /.well-known/l402 {
+location = /.well-known/l402-services {
     l402_manifest;
 
     # Optional: restrict who can scrape pricing details.
@@ -107,7 +107,7 @@ on the location:
 location /internal-paid {
     l402 on;
     l402_amount_msat_default 100000;
-    l402_manifest_hide;       # not advertised in /.well-known/l402
+    l402_manifest_hide;       # not advertised in /.well-known/l402-services
 }
 ```
 
@@ -156,7 +156,7 @@ formats out of band. With one, an agent can land on a host and onboard
 itself end-to-end:
 
 ```text
-GET /.well-known/l402         → learn the API surface
+GET /.well-known/l402-services  → learn the API surface
 GET /protected                → receive 402 + bolt11 invoice
 PAY the invoice               → get preimage
 GET /protected with L402 auth → success

--- a/nginx.conf
+++ b/nginx.conf
@@ -106,7 +106,7 @@ http {
         # Capability manifest. Lets agents (and humans) discover this
         # instance's paid routes, prices, and accepted payment backends
         # via a single JSON document — the agent-era robots.txt.
-        location = /.well-known/l402 {
+        location = /.well-known/l402-services {
             l402_manifest;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ static INIT: Once = Once::new();
 static mut MODULE: Option<L402Module> = None;
 
 /// Registry of l402-enabled locations, populated at config-parse time and
-/// drained at `.well-known/l402` request time. Each entry holds the
+/// drained at `.well-known/l402-services` request time. Each entry holds the
 /// location's path and a raw pointer to its `ModuleConfig` — the config
 /// lives in nginx's cycle pool, so the pointer remains valid until the
 /// next reload, at which point a fresh worker process is started with a
@@ -820,7 +820,7 @@ impl HttpModule for L402Module {
         // On `nginx -s reload`, the master parses the new config; without
         // this clear we'd accumulate stale (path, conf_ptr) entries from
         // the previous cycle whose pool memory has been freed — reading
-        // them later from /.well-known/l402 is a use-after-free.
+        // them later from /.well-known/l402-services is a use-after-free.
         if let Ok(mut reg) = manifest_registry().lock() {
             reg.clear();
         }
@@ -871,7 +871,7 @@ pub struct ModuleConfig {
     // stops inheritance.
     dry_run: Option<bool>,
     // When set via `l402_manifest_hide;`, this route is excluded from the
-    // `.well-known/l402` capability manifest. The route is still gated as
+    // `.well-known/l402-services` capability manifest. The route is still gated as
     // normal — this just makes it not discoverable.
     manifest_hidden: bool,
 }
@@ -2320,7 +2320,7 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_set(
         }
         (*clcf).handler = Some(l402_manifest_content_handler);
     }
-    info!("⚙️ l402_manifest endpoint registered (.well-known/l402 capability manifest)");
+    info!("⚙️ l402_manifest endpoint registered (.well-known/l402-services capability manifest)");
     std::ptr::null_mut()
 }
 
@@ -2335,12 +2335,12 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_hide_set(
         let conf = &mut *(conf as *mut ModuleConfig);
         conf.manifest_hidden = true;
     }
-    info!("⚙️ l402_manifest_hide: excluding this route from /.well-known/l402");
+    info!("⚙️ l402_manifest_hide: excluding this route from /.well-known/l402-services");
     std::ptr::null_mut()
 }
 
 /// Content-phase handler for `l402_manifest`. Serves the
-/// `.well-known/l402` capability manifest as JSON.
+/// `.well-known/l402-services` capability manifest as JSON.
 ///
 /// Only `GET` and `HEAD` are accepted; anything else returns `405`. The
 /// manifest is rebuilt on every request — cheap because the registry is
@@ -2449,7 +2449,7 @@ pub unsafe extern "C" fn ngx_http_l402_set(
                 conf.enable = true;
                 info!("⚙️ Enabled L402 for this location");
                 // Snapshot the location's path now and remember the conf
-                // pointer; the `.well-known/l402` handler re-reads the conf
+                // pointer; the `.well-known/l402-services` handler re-reads the conf
                 // at request time so post-merge values (amount_msat, etc.)
                 // are picked up correctly.
                 if let Some(path) = location_name_str(cf) {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-//! `.well-known/l402` capability manifest.
+//! `.well-known/l402-services` capability manifest.
 //!
 //! Renders a machine-readable JSON description of every L402-protected
 //! location in the running configuration, so agents (and humans) can


### PR DESCRIPTION
## Summary

Renames the capability-manifest path from `/.well-known/l402` to `/.well-known/l402-services` in the example nginx config, docs, and source comments/log lines.