### PR TITLE
fix: return 402 instead of 500 when LND invoice is not found during auto-detect

### DIFF
--- a/src/payment_detector.rs
+++ b/src/payment_detector.rs
@@ -148,11 +148,23 @@ impl LndDetector {
             ..Default::default()
         };
 
-        let response: tonic::Response<lnrpc::Invoice> = client
+        let response: tonic::Response<lnrpc::Invoice> = match client
             .lightning()
             .lookup_invoice(tonic::Request::new(request))
             .await
-            .map_err(|e| format!("LookupInvoice gRPC error: {}", e))?;
+        {
+            Ok(resp) => resp,
+            Err(status) => {
+                if status.code() == tonic::Code::NotFound {
+                    warn!(
+                        "⚠️  LND: invoice not found for payment_hash {}",
+                        &hex::encode(payment_hash)[..16]
+                    );
+                    return Ok(None);
+                }
+                return Err(format!("LookupInvoice gRPC error: {}", status));
+            }
+        };
 
         let invoice = response.into_inner();
 


### PR DESCRIPTION
## What
Align LND auto-detect behavior with CLN and Eclair by returning 402 (fresh challenge) instead of 500 when `LookupInvoice` reports gRPC `NOT_FOUND`.

## Why
With `l402_auto_detect_payment` enabled, a client can send `Authorization: L402 <macaroon>` without a preimage. The module looks up settlement on the Lightning node by payment hash.

- **CLN**: empty `listinvoices` → 402
- **Eclair**: HTTP 404 handled explicitly → 402
- **LND**: gRPC `NOT_FOUND` converted to `Err` → 500

This is inconsistent across backends for the same logical condition (unknown / stale / forged payment-hash macaroon). Missing invoices are routine (wrong server, expired/pruned hashes, probing clients), not an internal nginx/LND-integration failure.

## How
In `src/payment_detector.rs`, `LndDetector::lookup`:
- Replaced `.map_err(...)?` on `lookup_invoice` with an explicit `match`
- When the gRPC status code is `tonic::Code::NotFound`, log a warning and return `Ok(None)`
- All other gRPC errors still propagate as `Err` → 500

This routes LND through the existing `Ok(None) → 402` path in `l402_access_handler`, matching the pattern already used by Eclair and CLN.

## Checklist
- [x] Code formatted and linted
- [x] No breaking changes 

Closes #110 