### PR TITLE
feat: add l402_indefinite_access directive for subscription access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -855,6 +855,16 @@ jobs:
             exit 1
           fi
 
+          # Replaying the same valid preimage on a non-indefinite route must be rejected
+          echo "Testing protected route with reused preimage (should be rejected)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Authorization: L402 $macaroon:$preimage" http://0.0.0.0:8000/protected-timeout)
+          status_code=$(echo "$response" | tail -n1)
+          if [ "$status_code" -ne 401 ]; then
+            echo "Error: Reused preimage returned status $status_code, expected 401"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
           # Wait for macaroon to expire (10 seconds)
           echo "Waiting for macaroon to expire..."
           sleep 15
@@ -865,6 +875,57 @@ jobs:
           status_code=$(echo "$response" | tail -n1)
           if [ "$status_code" -ne 401 ]; then
             echo "Error: Protected route with expired macaroon returned status $status_code, expected 401"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
+          # Test indefinite-access: same preimage can be reused for the macaroon lifetime
+          echo "Testing indefinite-access route..."
+          response=$(curl -s -i -w "\n%{http_code}" --max-time 30 -L http://0.0.0.0:8000/protected-indefinite)
+          status_code=$(echo "$response" | tail -n1)
+          if [ "$status_code" -ne 402 ]; then
+            echo "Error: Indefinite-access route without header returned status $status_code, expected 402"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
+          invoice_indef=$(echo "$response" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
+          macaroon_indef=$(echo "$response" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          if [ -z "$invoice_indef" ] || [ -z "$macaroon_indef" ]; then
+            echo "Error: Missing invoice or macaroon for indefinite-access route"
+            echo "$response"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
+          echo "Paying indefinite-access invoice through LND..."
+          payment_result=$(docker exec lndnode lncli -n regtest payinvoice -f $invoice_indef 2>&1)
+          sleep 5
+
+          payment_result=$(docker exec lndnode lncli -n regtest listpayments | jq -r '.payments[-1]')
+          payment_status=$(echo "$payment_result" | jq -r '.status')
+          if [ "$payment_status" != "SUCCEEDED" ]; then
+            echo "Error: Indefinite-access payment failed or timed out"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
+          preimage_indef=$(echo "$payment_result" | jq -r '.payment_preimage')
+
+          echo "Testing indefinite-access route with valid preimage (first reuse)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Authorization: L402 $macaroon_indef:$preimage_indef" http://0.0.0.0:8000/protected-indefinite)
+          status_code=$(echo "$response" | tail -n1)
+          if [ "$status_code" -ne 200 ]; then
+            echo "Error: Indefinite-access route first reuse returned status $status_code, expected 200"
+            docker logs nginx-nwc
+            exit 1
+          fi
+
+          echo "Testing indefinite-access route with same preimage (second reuse - should still pass)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Authorization: L402 $macaroon_indef:$preimage_indef" http://0.0.0.0:8000/protected-indefinite)
+          status_code=$(echo "$response" | tail -n1)
+          if [ "$status_code" -ne 200 ]; then
+            echo "Error: Indefinite-access route second reuse returned status $status_code, expected 200"
             docker logs nginx-nwc
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -855,16 +855,6 @@ jobs:
             exit 1
           fi
 
-          # Replaying the same valid preimage on a non-indefinite route must be rejected
-          echo "Testing protected route with reused preimage (should be rejected)..."
-          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Authorization: L402 $macaroon:$preimage" http://0.0.0.0:8000/protected-timeout)
-          status_code=$(echo "$response" | tail -n1)
-          if [ "$status_code" -ne 401 ]; then
-            echo "Error: Reused preimage returned status $status_code, expected 401"
-            docker logs nginx-nwc
-            exit 1
-          fi
-
           # Wait for macaroon to expire (10 seconds)
           echo "Waiting for macaroon to expire..."
           sleep 15
@@ -1141,6 +1131,18 @@ jobs:
           status_code=$(echo "$response" | tail -n1)
           if [ "$status_code" -ne 200 ]; then
             echo "Error: Protected route with valid L402 returned status $status_code, expected 200"
+            docker logs nginx-lnd
+            exit 1
+          fi
+
+          # Replaying the same valid preimage on a non-indefinite route must be rejected
+          echo "Testing protected route with reused preimage (should be rejected)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 \
+            -H "Authorization: L402 $cred_macaroon:$cred_preimage" \
+            http://0.0.0.0:8000/protected)
+          status_code=$(echo "$response" | tail -n1)
+          if [ "$status_code" -ne 401 ]; then
+            echo "Error: Reused preimage returned status $status_code, expected 401"
             docker logs nginx-lnd
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY --from=builder /tmp/libngx_l402_lib.so /etc/nginx/modules/libngx_l402_lib.s
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY index.html /usr/share/nginx/html/protected/index.html
 COPY index.html /usr/share/nginx/html/protected-timeout/index.html
+COPY index.html /usr/share/nginx/html/protected-indefinite/index.html
 COPY index.html /usr/share/nginx/html/rate-limited/index.html
 COPY index.html /usr/share/nginx/html/shadow/index.html
 COPY index.html /usr/share/nginx/html/tenant1/index.html

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -174,6 +174,7 @@ These are set inside `location {}` blocks in `nginx.conf` (not environment varia
 | `l402_lnurl_addr` | string | — | Per-location LNURL address for multi-tenant setups |
 | `l402_invoice_rate_limit` | `<N>r/m` or `<N>r/s` | disabled | Max invoice generation rate per IP per route |
 | `l402_auto_detect_payment` | boolean¹ | `off` | Server-side payment detection — queries the Lightning node instead of requiring the client to supply the preimage |
+| `l402_indefinite_access` | boolean¹ | `off` | Skip the single-use preimage replay check — a single payment stays valid for the macaroon lifetime |
 
 > ¹ **Boolean directives** accept: `on` / `off` / `true` / `false` / `1` / `0` / `yes` / `no` (case-insensitive).
 
@@ -189,6 +190,23 @@ location /protected {
     try_files /index.html =404;
 }
 ```
+
+### Example: subscription-style (indefinite) access
+
+```nginx
+location /subscriber-only {
+    l402                         on;
+    l402_amount_msat_default     100000;
+    l402_macaroon_timeout        2592000;  # 30 days
+    l402_indefinite_access       on;       # single payment stays valid until macaroon expires
+
+    try_files /index.html =404;
+}
+```
+
+> **Warning**: `l402_indefinite_access on` should always be paired with a non-zero
+> `l402_macaroon_timeout`. Without an expiry, the macaroon never expires and the
+> same preimage grants access forever.
 
 > **Backends that support auto-detect**: `LND`, `CLN`, `BOLT12`, `ECLAIR`.
 > `LNC`, `NWC`, and `LNURL` do **not** support server-side lookup.

--- a/nginx.conf
+++ b/nginx.conf
@@ -82,6 +82,18 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
+        # Indefinite-access endpoint: a single payment grants access for the
+        # lifetime of the macaroon. The same preimage can be reused repeatedly.
+        location /protected-indefinite {
+            root   /usr/share/nginx/html;
+            l402    on;
+            l402_amount_msat_default    10000;
+            l402_macaroon_timeout 60;
+            l402_indefinite_access on;
+
+            try_files $uri $uri/index.html =404;
+        }
+
         # Shadow-mode endpoint: L402 is evaluated (pricing, challenge
         # generation, structured logs, Prometheus counters) but payment is
         # NOT enforced. All requests return 200 OK regardless of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -896,13 +896,16 @@ pub struct ModuleConfig {
     // (inherit from parent scope); `Some(false)` explicitly turns it off and
     // stops inheritance.
     dry_run: Option<bool>,
+    // Skip single-use preimage replay check; one payment stays valid for the
+    // macaroon lifetime (pair with l402_macaroon_timeout). Defaults to false.
+    indefinite_access: bool,
     // When set via `l402_manifest_hide;`, this route is excluded from the
     // `.well-known/l402-services` capability manifest. The route is still gated as
     // normal — this just makes it not discoverable.
     manifest_hidden: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 11] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 12] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -979,6 +982,14 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 11] = [
         name: ngx_string!("l402_manifest_hide"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t,
         set: Some(ngx_http_l402_manifest_hide_set),
+        conf: NGX_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
+    ngx_command_t {
+        name: ngx_string!("l402_indefinite_access"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
+        set: Some(ngx_http_l402_indefinite_access_set),
         conf: NGX_HTTP_LOC_CONF_OFFSET,
         offset: 0,
         post: std::ptr::null_mut(),
@@ -1063,6 +1074,9 @@ impl Merge for ModuleConfig {
         }
         if prev.manifest_hidden {
             self.manifest_hidden = true;
+        }
+        if prev.indefinite_access {
+            self.indefinite_access = true;
         }
         Ok(())
     }
@@ -1193,6 +1207,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         invoice_rate_limit,
         auto_detect_payment,
         dry_run,
+        indefinite_access,
     ) = unsafe {
         // NOTE: `authorization` can be null — not every request carries the header.
         let auth_header = if !r.headers_in.authorization.is_null() {
@@ -1244,6 +1259,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let invoice_rate_limit = conf.invoice_rate_limit;
         let auto_detect_payment = conf.auto_detect_payment;
         let dry_run = conf.dry_run.unwrap_or(false);
+        let indefinite_access = conf.indefinite_access;
 
         (
             auth_header,
@@ -1255,6 +1271,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             invoice_rate_limit,
             auto_detect_payment,
             dry_run,
+            indefinite_access,
         )
     };
 
@@ -1322,6 +1339,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         caveats.clone(),
         final_lnurl_addr.clone(),
         auto_detect_payment,
+        indefinite_access,
     );
     let auth_duration = auth_start.elapsed();
 
@@ -1546,6 +1564,7 @@ pub fn l402_access_handler(
     caveats: Vec<String>,
     lnurl_addr: Option<String>,
     auto_detect_payment: bool,
+    indefinite_access: bool,
 ) -> isize {
     // Reset so the wrapper never reads a stale method from a prior request.
     LAST_PAYMENT_METHOD.with(|m| m.set(None));
@@ -1686,8 +1705,8 @@ pub fn l402_access_handler(
                         }
                     };
 
-                // 4. Check replay
-                if is_preimage_used(&preimage_bytes) {
+                // 4. Check replay (skipped when indefinite access is enabled).
+                if !indefinite_access && is_preimage_used(&preimage_bytes) {
                     error!("🚨 Replay attack detected: preimage already used");
                     return 401;
                 }
@@ -1742,6 +1761,10 @@ pub fn l402_access_handler(
                     Ok(_) => {
                         info!("✅ L402 auto-detect verification successful");
                         LAST_PAYMENT_METHOD.with(|m| m.set(Some(PaymentMethod::Lightning)));
+                        if indefinite_access {
+                            // Subscription mode: allow preimage reuse.
+                            return NGX_DECLINED as isize;
+                        }
                         // SET NX EX is the authoritative atomic admission gate.
                         // Ok(false) means another worker already claimed this
                         // preimage — treat as replay and reject.
@@ -1770,9 +1793,8 @@ pub fn l402_access_handler(
             match utils::parse_l402_header(&auth_str) {
                 Ok((mac, preimage)) => {
                     // Fast-fail: known-replayed preimages are rejected before
-                    // running macaroon verification. The SET NX EX below is the
-                    // authoritative cross-worker admission gate.
-                    if is_preimage_used(&preimage.0) {
+                    // macaroon verification. Skipped when indefinite access is enabled.
+                    if !indefinite_access && is_preimage_used(&preimage.0) {
                         warn!("🚨 Replay attack detected: preimage already used");
                         return 401;
                     }
@@ -1821,6 +1843,10 @@ pub fn l402_access_handler(
                         Ok(_) => {
                             info!("✅ L402 verification successful");
                             LAST_PAYMENT_METHOD.with(|m| m.set(Some(PaymentMethod::Lightning)));
+                            if indefinite_access {
+                                // Subscription mode: allow preimage reuse.
+                                return NGX_DECLINED as isize;
+                            }
                             // SET NX EX is the authoritative atomic admission gate.
                             // Ok(false) means another worker already claimed this
                             // preimage — treat as replay and reject.
@@ -2338,6 +2364,40 @@ pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
         } else {
             error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
             return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+pub unsafe extern "C" fn ngx_http_l402_indefinite_access_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf`, `conf`, and `(*cf).args` are guaranteed valid by Nginx
+    // during config-parsing callbacks. `args.add(1)` is safe because
+    // NGX_CONF_TAKE1 ensures exactly one argument is present.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        let args = (*(*cf).args).elts as *mut ngx_str_t;
+        let val = (*args.add(1)).to_str().unwrap_or_default();
+
+        if val.eq_ignore_ascii_case("on")
+            || val.eq_ignore_ascii_case("true")
+            || val.eq_ignore_ascii_case("1")
+            || val.eq_ignore_ascii_case("yes")
+        {
+            conf.indefinite_access = true;
+            info!("⚙️ l402_indefinite_access enabled — preimage replay check disabled for this location");
+        } else if val.eq_ignore_ascii_case("off")
+            || val.eq_ignore_ascii_case("false")
+            || val.eq_ignore_ascii_case("0")
+            || val.eq_ignore_ascii_case("no")
+        {
+            conf.indefinite_access = false;
+        } else {
+            error!("Invalid l402_indefinite_access value: '{}' (expected on/off)", val);
+            return b"l402_indefinite_access: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
         }
     }
     std::ptr::null_mut()


### PR DESCRIPTION
Adds a new `l402_indefinite_access` directive that skips the single-use preimage replay check for a location. This lets a single payment grant access for the lifetime of the macaroon, which is useful for subscription-style access.

Example:

```nginx
location /subscriber-only {
    l402 on;
    l402_amount_msat_default 100000;
    l402_macaroon_timeout 2592000;  # 30 days
    l402_indefinite_access on;
}
```
Defaults to `off`, so existing behavior is unchanged. Macaroon expiry, path, and method caveats are still enforced.

### Changes:

- Added `indefinite_access` to `ModuleConfig` and registered the directive.
- Threaded the flag through the access handler.
- Skipped the replay check and preimage-used store in both auto-detect and classic L402 paths when enabled.
- Added integration tests: a negative test confirming replay is rejected on normal routes, and a positive test confirming reuse works on indefinite-access routes.
- Updated `docs/config-env-vars.md` with the directive and an example.

This has to be paired with a non-zero `l402_macaroon_timeout`. Without an expiry, the macaroon never expires and the same preimage grants access forever.

Closes #91