### PR TITLE
feat(metrics): aggregate Prometheus counters across nginx workers via shared memory

### DIFF
--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -143,6 +143,12 @@ scrape_configs:
       - targets: ['nginx:8000']
 ```
 
+Counters are kept in an nginx **shared-memory zone**, so they are aggregated
+across all worker processes: a scrape served by any worker returns the true
+total regardless of `worker_processes`. (If the shared zone cannot be
+allocated at startup the module logs a warning and falls back to per-worker
+counters, which under-report by roughly a factor of `worker_processes`.)
+
 ### Exported counters
 
 | Metric | Meaning |

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -135,10 +135,11 @@ the manifest stays valid JSON even with no service metadata.
 
 ## Caveats and limitations
 
-- **Per-worker registry.** Like `l402_metrics`, the manifest registry is
-  per-nginx-worker. On a multi-worker deployment, every worker sees the
-  same routes (config is shared), so this is a non-issue for the manifest
-  itself.
+- **Per-worker registry.** The manifest registry is per-nginx-worker. On a
+  multi-worker deployment, every worker sees the same routes (config is
+  shared), so this is a non-issue for the manifest itself. (Unlike the
+  `l402_metrics` counters, which use a shared-memory zone, the registry is
+  read-only per-worker state and needs no cross-worker aggregation.)
 - **No authentication by default.** Pricing information is public.
   Restrict the endpoint with `allow`/`deny`, an auth subrequest, or a
   firewall if competitors should not see your full pricing matrix.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_chain_t, ngx_command_t, ngx_conf_t, ngx_cycle_s,
     ngx_http_discard_request_body, ngx_http_handler_pt, ngx_http_module_t,
     ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t,
+    ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc, ngx_slab_pool_t,
     ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_COPY,
     NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK,
     NGX_HTTP_LOC_CONF, NGX_HTTP_LOC_CONF_OFFSET, NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE,
@@ -865,8 +866,113 @@ impl HttpModule for L402Module {
         }
         // set an access phase handler for l402 (after location matching and rewrite)
         *h = Some(l402_access_handler_wrapper);
+
+        // Register the cross-worker metrics shared-memory zone. Failure is
+        // non-fatal: metrics fall back to per-worker counters (issue #105).
+        register_metrics_shm(cf);
+
         NGX_OK as ngx_int_t
     }
+}
+
+/// Name of the metrics shared-memory zone. nginx stores the pointer, so it must
+/// have `'static` lifetime; `ngx_string!` points at a NUL-terminated literal.
+static mut METRICS_SHM_NAME: ngx_str_t = ngx_string!("l402_metrics");
+
+/// Size of the metrics shared-memory zone. The block itself is tiny (a magic
+/// header + a fixed array of counters), but nginx needs room for the slab
+/// pool's own bookkeeping; 32 KiB is comfortably above the minimum on any page
+/// size while staying negligible.
+const METRICS_SHM_SIZE: usize = 32 * 1024;
+
+/// Register the metrics shared-memory zone during HTTP postconfiguration so its
+/// counters are shared across all worker processes (issue #105).
+///
+/// nginx allocates the zone in the master *before* it forks workers and maps it
+/// at the same address in every worker, so a single counter block is visible to
+/// all of them. The actual block is allocated and installed in
+/// [`metrics_shm_init`], which nginx invokes once the segment exists.
+///
+/// On any failure we log and return without installing a shared block; the
+/// `metrics` module then keeps using its process-local fallback, preserving the
+/// pre-existing per-worker behaviour rather than crashing.
+unsafe fn register_metrics_shm(cf: *mut ngx_conf_t) {
+    let tag = ::core::ptr::addr_of!(ngx_http_l402_module) as *mut c_void;
+    let zone = ngx_shared_memory_add(
+        cf,
+        ::core::ptr::addr_of_mut!(METRICS_SHM_NAME),
+        METRICS_SHM_SIZE,
+        tag,
+    );
+    if zone.is_null() {
+        error!("⚠️ l402_metrics: could not add shared memory zone; metrics will be per-worker");
+        return;
+    }
+    // nginx calls this once the segment is created (master, before fork).
+    (*zone).init = Some(metrics_shm_init);
+    // Leave `noreuse` at 0 so counters survive `nginx -s reload`.
+}
+
+/// Shared-memory zone init callback. Runs single-threaded in the master process
+/// before workers fork. Allocates (or reuses) the counter block from the zone's
+/// slab pool and installs it as the active store via [`metrics::install_shared`],
+/// so every forked worker inherits the pointer.
+unsafe extern "C" fn metrics_shm_init(zone: *mut ngx_shm_zone_t, data: *mut c_void) -> ngx_int_t {
+    // Reload carry-over: nginx passes the previous cycle's zone data so counters
+    // persist across `nginx -s reload`.
+    if !data.is_null() {
+        let block = data as *mut metrics::MetricsBlock;
+        if !metrics::magic_matches(block) {
+            metrics::init_in_place(block);
+        }
+        (*zone).data = data;
+        metrics::install_shared(block);
+        return NGX_OK as ngx_int_t;
+    }
+
+    let shpool = (*zone).shm.addr as *mut ngx_slab_pool_t;
+    if shpool.is_null() {
+        error!("⚠️ l402_metrics: shared zone has no slab pool; metrics will be per-worker");
+        return NGX_ERROR as ngx_int_t;
+    }
+
+    // Segment inherited from a prior process image (e.g. binary upgrade): the
+    // slab pool already holds our block via its `data` pointer.
+    if (*zone).shm.exists != 0 {
+        let block = (*shpool).data as *mut metrics::MetricsBlock;
+        if block.is_null() {
+            error!("⚠️ l402_metrics: inherited zone missing counter block");
+            return NGX_ERROR as ngx_int_t;
+        }
+        if !metrics::magic_matches(block) {
+            metrics::init_in_place(block);
+        }
+        (*zone).data = block as *mut c_void;
+        metrics::install_shared(block);
+        return NGX_OK as ngx_int_t;
+    }
+
+    // Fresh zone: allocate the counter block from the slab pool. `ngx_slab_alloc`
+    // takes the pool mutex internally — correct here (and the same call
+    // `ngx_http_limit_req` uses in its init_zone), even though this runs
+    // single-threaded in the master before fork.
+    let raw = ngx_slab_alloc(shpool, metrics::BLOCK_SIZE);
+    if raw.is_null() {
+        error!("⚠️ l402_metrics: slab allocation failed; metrics will be per-worker");
+        return NGX_ERROR as ngx_int_t;
+    }
+    if (raw as usize) % metrics::BLOCK_ALIGN != 0 {
+        // Should not happen (slab slots are at least word-aligned), but writing
+        // an AtomicU64 array through a misaligned pointer would be UB.
+        error!("⚠️ l402_metrics: slab allocation misaligned; metrics will be per-worker");
+        return NGX_ERROR as ngx_int_t;
+    }
+    let block = raw as *mut metrics::MetricsBlock;
+    metrics::init_in_place(block);
+    (*shpool).data = block as *mut c_void;
+    (*zone).data = block as *mut c_void;
+    metrics::install_shared(block);
+    NGX_OK as ngx_int_t
 }
 
 unsafe impl HttpModuleLocationConf for L402Module {
@@ -1328,7 +1434,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         (amount_msat, lnurl_addr, "static")
     };
 
-    metrics::inc(&metrics::L402_REQUESTS_TOTAL);
+    metrics::inc(metrics::Metric::RequestsTotal);
     let auth_present = auth_header.is_some();
     let auth_start = Instant::now();
     let result = l402_access_handler(
@@ -1375,19 +1481,19 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     // holds and shadow traffic never ticks them.
     match result {
         r if r == NGX_DECLINED as isize => {
-            metrics::inc(&metrics::L402_PAYMENTS_VALID_TOTAL);
+            metrics::inc(metrics::Metric::PaymentsValidTotal);
             match LAST_PAYMENT_METHOD.with(|m| m.take()) {
                 Some(PaymentMethod::Lightning) => {
-                    metrics::inc(&metrics::L402_PAYMENTS_LIGHTNING_TOTAL)
+                    metrics::inc(metrics::Metric::PaymentsLightningTotal)
                 }
                 Some(PaymentMethod::Cashu) => {
-                    metrics::inc(&metrics::L402_PAYMENTS_CASHU_TOTAL)
+                    metrics::inc(metrics::Metric::PaymentsCashuTotal)
                 }
                 None => {}
             }
         }
-        401 => metrics::inc(&metrics::L402_PAYMENTS_INVALID_TOTAL),
-        402 => metrics::inc(&metrics::L402_PAYMENTS_MISSING_TOTAL),
+        401 => metrics::inc(metrics::Metric::PaymentsInvalidTotal),
+        402 => metrics::inc(metrics::Metric::PaymentsMissingTotal),
         _ => {}
     }
 
@@ -1396,7 +1502,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
-                metrics::inc(&metrics::L402_RATE_LIMITED_TOTAL);
+                metrics::inc(metrics::Metric::RateLimitedTotal);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
@@ -1414,7 +1520,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             }
         }
         // Only count as "issued" once we're past the rate-limit gate.
-        metrics::inc(&metrics::L402_CHALLENGES_ISSUED_TOTAL);
+        metrics::inc(metrics::Metric::ChallengesIssuedTotal);
 
         let rt = get_handler_runtime();
 
@@ -1497,7 +1603,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
 
         match header_result {
             Some(header_value) => {
-                metrics::inc(&metrics::L402_INVOICES_GENERATED_TOTAL);
+                metrics::inc(metrics::Metric::InvoicesGeneratedTotal);
 
                 // Set WWW-Authenticate header for API clients
                 unsafe {
@@ -1537,7 +1643,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 // Fallback: could not parse header, return plain 402
             }
             None => {
-                metrics::inc(&metrics::L402_INVOICES_GENERATION_ERRORS_TOTAL);
+                metrics::inc(metrics::Metric::InvoicesGenerationErrorsTotal);
                 ngx_log_error!(NGX_LOG_ERR, log_ref, "Failed to get L402 header");
                 return 500;
             }
@@ -2112,9 +2218,9 @@ fn handle_dry_run_passthrough(
     auth_present: bool,
     invoice_rate_limit: Option<(u32, u64)>,
 ) -> isize {
-    metrics::inc(&metrics::L402_DRY_RUN_REQUESTS_TOTAL);
+    metrics::inc(metrics::Metric::DryRunRequestsTotal);
     if final_amount > 0 {
-        metrics::add(&metrics::L402_DRY_RUN_PRICE_MSAT_SUM, final_amount as u64);
+        metrics::add(metrics::Metric::DryRunPriceMsatSum, final_amount as u64);
     }
 
     let would_return: u16 = match result {
@@ -2141,12 +2247,12 @@ fn handle_dry_run_passthrough(
     };
 
     match would_return {
-        200 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_ALLOW_TOTAL),
-        401 | 402 => metrics::inc(&metrics::L402_DRY_RUN_WOULD_BLOCK_TOTAL),
+        200 => metrics::inc(metrics::Metric::DryRunWouldAllowTotal),
+        401 | 402 => metrics::inc(metrics::Metric::DryRunWouldBlockTotal),
         _ => {}
     }
     if rate_limited {
-        metrics::inc(&metrics::L402_DRY_RUN_RATE_LIMITED_TOTAL);
+        metrics::inc(metrics::Metric::DryRunRateLimitedTotal);
     }
 
     let auth_state = match (auth_present, result) {
@@ -2208,7 +2314,7 @@ fn handle_dry_run_passthrough(
                 req.add_header_out("X-L402-Dry-Run-Challenge", &header_value);
             }
             Ok(None) => {
-                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                metrics::inc(metrics::Metric::DryRunChallengeErrorsTotal);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,
@@ -2217,7 +2323,7 @@ fn handle_dry_run_passthrough(
                 );
             }
             Err(_) => {
-                metrics::inc(&metrics::L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL);
+                metrics::inc(metrics::Metric::DryRunChallengeErrorsTotal);
                 ngx_log_error!(
                     NGX_LOG_WARN,
                     log_ref,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,184 +1,261 @@
 //! Prometheus-format counters for ngx_l402.
 //!
-//! Counters are global [`AtomicU64`]s updated from the access handler on the
-//! hot path; exposition format is rendered lazily via [`render`] when an
-//! operator scrapes the `l402_metrics` endpoint.
+//! Counters live in a single fixed-layout [`MetricsBlock`] of [`AtomicU64`]s.
+//! The active block is normally an nginx **shared-memory** allocation installed
+//! by the master process before it forks workers (see `register_metrics_shm` in
+//! `lib.rs`), so every worker increments the *same* physical atomics and a
+//! `/metrics` scrape served by any worker returns the true cross-worker total
+//! (issue #105).
+//!
+//! If the shared zone is unavailable — registration or slab allocation failed —
+//! the active block falls back to a process-local [`static`], degrading to the
+//! old per-worker counts rather than crashing. The hot-path cost is identical
+//! either way: a single relaxed `fetch_add` on a memory address.
 //!
 //! No label dimensions are used — per-route or per-backend granularity is
 //! intentionally left to the structured JSON log line emitted for each
 //! dry-run request (see `handle_dry_run_passthrough` in `lib.rs`).
 
 use core::fmt::Write;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicPtr, AtomicU64, Ordering};
 
-macro_rules! counters {
-    ($($(#[$attr:meta])* $name:ident),* $(,)?) => {
-        $(
-            $(#[$attr])*
-            pub static $name: AtomicU64 = AtomicU64::new(0);
-        )*
-    };
-}
-
-counters! {
+/// Stable index for each counter.
+///
+/// The numeric discriminants are part of the shared-memory layout: counters
+/// can be carried over across an `nginx -s reload` that reuses the segment, so
+/// **only append** new variants at the end. Reordering or removing a variant
+/// changes the meaning of already-stored slots. Any layout change must bump
+/// [`MAGIC`] so a reused segment from an incompatible build is re-initialised.
+#[derive(Clone, Copy)]
+#[repr(usize)]
+pub enum Metric {
     /// Every request that entered the L402 access handler with `l402 on;`,
     /// regardless of whether enforcement was active.
-    L402_REQUESTS_TOTAL,
-
+    RequestsTotal = 0,
     /// Requests that resulted in a 402 Payment Required response (enforced mode).
-    L402_CHALLENGES_ISSUED_TOTAL,
-
-    /// Requests whose Authorization header verified successfully.
-    /// Aggregate of [`L402_PAYMENTS_LIGHTNING_TOTAL`] and
-    /// [`L402_PAYMENTS_CASHU_TOTAL`].
-    L402_PAYMENTS_VALID_TOTAL,
-
+    ChallengesIssuedTotal,
+    /// Requests whose Authorization header verified successfully. Aggregate of
+    /// [`Metric::PaymentsLightningTotal`] and [`Metric::PaymentsCashuTotal`].
+    PaymentsValidTotal,
     /// Successful payments settled via a Lightning macaroon (classic preimage
     /// path *or* auto-detect path).
-    L402_PAYMENTS_LIGHTNING_TOTAL,
-
+    PaymentsLightningTotal,
     /// Successful payments settled via a Cashu token redemption.
-    L402_PAYMENTS_CASHU_TOTAL,
-
+    PaymentsCashuTotal,
     /// Requests whose Authorization header failed verification (401).
-    L402_PAYMENTS_INVALID_TOTAL,
-
+    PaymentsInvalidTotal,
     /// Requests that arrived without an Authorization header.
-    L402_PAYMENTS_MISSING_TOTAL,
-
+    PaymentsMissingTotal,
     /// Lightning invoices successfully generated as part of a 402 challenge.
-    L402_INVOICES_GENERATED_TOTAL,
-
-    /// Lightning invoice generation failures (LN backend unreachable, LNURL
-    /// errors, etc.) that resulted in a 500 response.
-    L402_INVOICES_GENERATION_ERRORS_TOTAL,
-
+    InvoicesGeneratedTotal,
+    /// Lightning invoice generation failures that resulted in a 500 response.
+    InvoicesGenerationErrorsTotal,
     /// Requests rejected with 429 by `l402_invoice_rate_limit` (enforce mode).
-    L402_RATE_LIMITED_TOTAL,
-
+    RateLimitedTotal,
     /// Total requests handled in dry-run (shadow) mode.
-    L402_DRY_RUN_REQUESTS_TOTAL,
-
-    /// Dry-run requests that *would* have been blocked (401 or 402) in
-    /// enforce mode.
-    L402_DRY_RUN_WOULD_BLOCK_TOTAL,
-
+    DryRunRequestsTotal,
+    /// Dry-run requests that *would* have been blocked (401 or 402) in enforce mode.
+    DryRunWouldBlockTotal,
     /// Dry-run requests that *would* have been allowed through (valid token).
-    L402_DRY_RUN_WOULD_ALLOW_TOTAL,
-
+    DryRunWouldAllowTotal,
     /// Dry-run requests where challenge synthesis (invoice generation) failed.
-    L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
-
-    /// Dry-run requests that would have been rejected with 429 by the
-    /// invoice rate limiter had enforcement been on.
-    L402_DRY_RUN_RATE_LIMITED_TOTAL,
-
+    DryRunChallengeErrorsTotal,
+    /// Dry-run requests that would have been rejected with 429 by the invoice
+    /// rate limiter had enforcement been on.
+    DryRunRateLimitedTotal,
     /// Sum of msat prices evaluated for dry-run requests. Divide by
     /// `l402_dry_run_requests_total` for an average-price gauge.
-    L402_DRY_RUN_PRICE_MSAT_SUM,
+    DryRunPriceMsatSum,
+}
+
+impl Metric {
+    /// Number of counters in [`MetricsBlock`]. Must equal the count of [`Metric`]
+    /// variants and the length of [`ENTRIES`].
+    pub const COUNT: usize = 16;
+}
+
+// Compile-time guards keeping the enum, `COUNT`, and `ENTRIES` in lockstep:
+//   * the last variant's discriminant must be `COUNT - 1`, so appending a
+//     variant without bumping `COUNT` (or vice versa) fails to compile;
+//   * `ENTRIES` is typed `[_; Metric::COUNT]`, so its length is pinned to
+//     `COUNT` by the array type itself.
+// Together these make a misindexed Prometheus label impossible to introduce
+// silently.
+const _: () = assert!(Metric::DryRunPriceMsatSum as usize + 1 == Metric::COUNT);
+
+/// Prometheus metric name + HELP text for each counter, in [`Metric`] order.
+/// The index of each row must match the corresponding [`Metric`] discriminant.
+static ENTRIES: [(&str, &str); Metric::COUNT] = [
+    (
+        "l402_requests_total",
+        "Total L402-protected requests seen by the access handler.",
+    ),
+    (
+        "l402_challenges_issued_total",
+        "L402 challenges returned to clients (HTTP 402 in enforce mode).",
+    ),
+    (
+        "l402_payments_valid_total",
+        "Authorization headers that verified successfully (Lightning + Cashu).",
+    ),
+    (
+        "l402_payments_lightning_total",
+        "Successful payments settled via a Lightning macaroon.",
+    ),
+    (
+        "l402_payments_cashu_total",
+        "Successful payments settled via a Cashu token redemption.",
+    ),
+    (
+        "l402_payments_invalid_total",
+        "Authorization headers that failed verification.",
+    ),
+    (
+        "l402_payments_missing_total",
+        "Requests without an Authorization header.",
+    ),
+    (
+        "l402_invoices_generated_total",
+        "Lightning invoices successfully generated for L402 challenges.",
+    ),
+    (
+        "l402_invoices_generation_errors_total",
+        "Failures generating a Lightning invoice during L402 challenge synthesis.",
+    ),
+    (
+        "l402_rate_limited_total",
+        "Requests rejected with 429 by l402_invoice_rate_limit.",
+    ),
+    (
+        "l402_dry_run_requests_total",
+        "Requests handled in dry-run (shadow) mode.",
+    ),
+    (
+        "l402_dry_run_would_block_total",
+        "Dry-run requests that would have been blocked in enforce mode.",
+    ),
+    (
+        "l402_dry_run_would_allow_total",
+        "Dry-run requests that would have been allowed through in enforce mode.",
+    ),
+    (
+        "l402_dry_run_challenge_errors_total",
+        "Dry-run requests where L402 challenge synthesis failed.",
+    ),
+    (
+        "l402_dry_run_rate_limited_total",
+        "Dry-run requests that would have been rate-limited in enforce mode.",
+    ),
+    (
+        "l402_dry_run_price_msat_sum",
+        "Cumulative msat price evaluated across dry-run requests.",
+    ),
+];
+
+/// Sentinel written into a freshly-initialised [`MetricsBlock`]. Lets the shm
+/// zone init callback detect a reused segment that was populated by a
+/// *compatible* build and reuse its counters; a mismatch (e.g. after a binary
+/// upgrade that changed the layout) triggers re-initialisation. Bump the low
+/// bytes whenever [`Metric`]/[`MetricsBlock`] layout changes.
+const MAGIC: u64 = 0x4c34_3032_4d54_0001; // 'L402MT' + layout version 0001
+
+/// Fixed-layout block of counters placed either in process-local memory or in
+/// an nginx shared-memory zone. `#[repr(C)]` keeps the field order stable so a
+/// pointer into shared memory is interpreted identically by every worker.
+#[repr(C)]
+pub struct MetricsBlock {
+    magic: AtomicU64,
+    counters: [AtomicU64; Metric::COUNT],
+}
+
+impl MetricsBlock {
+    const fn new() -> Self {
+        MetricsBlock {
+            magic: AtomicU64::new(MAGIC),
+            counters: [const { AtomicU64::new(0) }; Metric::COUNT],
+        }
+    }
+}
+
+/// Size and alignment of [`MetricsBlock`], for the slab allocation in the shm
+/// zone init callback.
+pub const BLOCK_SIZE: usize = core::mem::size_of::<MetricsBlock>();
+pub const BLOCK_ALIGN: usize = core::mem::align_of::<MetricsBlock>();
+
+/// Process-local fallback used until (or unless) a shared block is installed.
+static LOCAL_BLOCK: MetricsBlock = MetricsBlock::new();
+
+/// Active counter store. Null until [`install_shared`] points it at a
+/// shared-memory block; reads fall back to [`LOCAL_BLOCK`] while null.
+static ACTIVE: AtomicPtr<MetricsBlock> = AtomicPtr::new(core::ptr::null_mut());
+
+#[inline]
+fn block() -> &'static MetricsBlock {
+    // Acquire pairs with the Release store in `install_shared`, so a worker that
+    // sees a non-null pointer also sees the block's initialised contents.
+    let p = ACTIVE.load(Ordering::Acquire);
+    if p.is_null() {
+        // No shared block installed (registration/alloc failed): use the
+        // process-local fallback, i.e. the pre-#105 per-worker behaviour.
+        &LOCAL_BLOCK
+    } else {
+        // SAFETY: a non-null ACTIVE was installed by `install_shared` with a
+        // pointer to a valid MetricsBlock in the shared zone, which lives for
+        // the lifetime of the process (and is mapped at the same address in
+        // every worker via the inherited shared mapping).
+        unsafe { &*p }
+    }
+}
+
+/// Install `ptr` as the active counter store.
+///
+/// Called from the shm zone init callback in the **master** process before
+/// workers fork, so the pointer is inherited by every worker. `ptr` must point
+/// at an initialised [`MetricsBlock`] (see [`init_in_place`]) that outlives the
+/// process. Passing null reverts to the process-local fallback.
+pub fn install_shared(ptr: *mut MetricsBlock) {
+    ACTIVE.store(ptr, Ordering::Release);
+}
+
+/// Initialise a [`MetricsBlock`] in place at `ptr` (writes the magic header and
+/// zeroes all counters).
+///
+/// # Safety
+/// `ptr` must be non-null, [`BLOCK_ALIGN`]-aligned, and valid for writes of
+/// [`BLOCK_SIZE`] bytes. The memory must not be concurrently accessed (the shm
+/// zone init callback runs single-threaded in the master before fork).
+pub unsafe fn init_in_place(ptr: *mut MetricsBlock) {
+    core::ptr::write(ptr, MetricsBlock::new());
+}
+
+/// Whether the block at `ptr` carries the current [`MAGIC`] (i.e. was
+/// initialised by a layout-compatible build).
+///
+/// # Safety
+/// `ptr` must be non-null, aligned, and valid for reads of [`BLOCK_SIZE`] bytes.
+pub unsafe fn magic_matches(ptr: *const MetricsBlock) -> bool {
+    (*ptr).magic.load(Ordering::Relaxed) == MAGIC
 }
 
 #[inline]
-pub fn inc(c: &AtomicU64) {
-    c.fetch_add(1, Ordering::Relaxed);
+pub fn inc(m: Metric) {
+    block().counters[m as usize].fetch_add(1, Ordering::Relaxed);
 }
 
 #[inline]
-pub fn add(c: &AtomicU64, n: u64) {
-    c.fetch_add(n, Ordering::Relaxed);
+pub fn add(m: Metric, n: u64) {
+    block().counters[m as usize].fetch_add(n, Ordering::Relaxed);
 }
 
 /// Render all counters in Prometheus text exposition format (version 0.0.4).
 pub fn render() -> String {
-    static ENTRIES: &[(&str, &str, &AtomicU64)] = &[
-        (
-            "l402_requests_total",
-            "Total L402-protected requests seen by the access handler.",
-            &L402_REQUESTS_TOTAL,
-        ),
-        (
-            "l402_challenges_issued_total",
-            "L402 challenges returned to clients (HTTP 402 in enforce mode).",
-            &L402_CHALLENGES_ISSUED_TOTAL,
-        ),
-        (
-            "l402_payments_valid_total",
-            "Authorization headers that verified successfully (Lightning + Cashu).",
-            &L402_PAYMENTS_VALID_TOTAL,
-        ),
-        (
-            "l402_payments_lightning_total",
-            "Successful payments settled via a Lightning macaroon.",
-            &L402_PAYMENTS_LIGHTNING_TOTAL,
-        ),
-        (
-            "l402_payments_cashu_total",
-            "Successful payments settled via a Cashu token redemption.",
-            &L402_PAYMENTS_CASHU_TOTAL,
-        ),
-        (
-            "l402_payments_invalid_total",
-            "Authorization headers that failed verification.",
-            &L402_PAYMENTS_INVALID_TOTAL,
-        ),
-        (
-            "l402_payments_missing_total",
-            "Requests without an Authorization header.",
-            &L402_PAYMENTS_MISSING_TOTAL,
-        ),
-        (
-            "l402_invoices_generated_total",
-            "Lightning invoices successfully generated for L402 challenges.",
-            &L402_INVOICES_GENERATED_TOTAL,
-        ),
-        (
-            "l402_invoices_generation_errors_total",
-            "Failures generating a Lightning invoice during L402 challenge synthesis.",
-            &L402_INVOICES_GENERATION_ERRORS_TOTAL,
-        ),
-        (
-            "l402_rate_limited_total",
-            "Requests rejected with 429 by l402_invoice_rate_limit.",
-            &L402_RATE_LIMITED_TOTAL,
-        ),
-        (
-            "l402_dry_run_requests_total",
-            "Requests handled in dry-run (shadow) mode.",
-            &L402_DRY_RUN_REQUESTS_TOTAL,
-        ),
-        (
-            "l402_dry_run_would_block_total",
-            "Dry-run requests that would have been blocked in enforce mode.",
-            &L402_DRY_RUN_WOULD_BLOCK_TOTAL,
-        ),
-        (
-            "l402_dry_run_would_allow_total",
-            "Dry-run requests that would have been allowed through in enforce mode.",
-            &L402_DRY_RUN_WOULD_ALLOW_TOTAL,
-        ),
-        (
-            "l402_dry_run_challenge_errors_total",
-            "Dry-run requests where L402 challenge synthesis failed.",
-            &L402_DRY_RUN_CHALLENGE_ERRORS_TOTAL,
-        ),
-        (
-            "l402_dry_run_rate_limited_total",
-            "Dry-run requests that would have been rate-limited in enforce mode.",
-            &L402_DRY_RUN_RATE_LIMITED_TOTAL,
-        ),
-        (
-            "l402_dry_run_price_msat_sum",
-            "Cumulative msat price evaluated across dry-run requests.",
-            &L402_DRY_RUN_PRICE_MSAT_SUM,
-        ),
-    ];
-
+    let b = block();
     let mut out = String::with_capacity(ENTRIES.len() * 128);
-    for (name, help, counter) in ENTRIES {
+    for (i, (name, help)) in ENTRIES.iter().enumerate() {
         // writeln! into String is infallible; ignore Result without unwrap.
         let _ = writeln!(out, "# HELP {} {}", name, help);
         let _ = writeln!(out, "# TYPE {} counter", name);
-        let _ = writeln!(out, "{} {}", name, counter.load(Ordering::Relaxed));
+        let _ = writeln!(out, "{} {}", name, b.counters[i].load(Ordering::Relaxed));
     }
     out
 }


### PR DESCRIPTION
Closes #105.

## Problem

The `l402_metrics` Prometheus counters were process-local `AtomicU64` statics. nginx forks one worker per CPU core (`worker_processes auto;`), and each fork gets its own copy, so a `/metrics` scrape returned whichever worker happened to serve it — typically a ~`1/worker_processes` slice of real traffic. Absolute counts and cross-counter ratios were unreliable; the only workaround was `worker_processes 1;`.

## Approach

Move the counters into a single fixed-layout block held in an **nginx shared-memory zone** — the same idiom nginx's own `stub_status` uses (lock-free atomic counters in shm). The zone is allocated by the master *before* it forks and is mapped at the same address in every worker, so all workers increment the same physical atomics and any scrape returns the true cross-worker total.

### `src/metrics.rs`
- 16 standalone `static AtomicU64`s → one `#[repr(C)] MetricsBlock { magic, counters: [AtomicU64; 16] }`, addressed by a stable `Metric` enum index.
- An `AtomicPtr` (`ACTIVE`) selects either the shared block or a process-local fallback (`Acquire`/`Release` pairing so workers see initialised contents).
- A `MAGIC` header versions the layout, so a reload that reuses the segment from an incompatible build re-initialises rather than misreading slots.
- A `const _: () = assert!(...)` pins the enum ↔ `COUNT` ↔ `ENTRIES` together at compile time, so a misindexed Prometheus label is impossible to introduce silently.

### `src/lib.rs`
- `register_metrics_shm()` adds the zone in HTTP postconfiguration.
- The init callback allocates the block from the zone's slab pool (handling the three nginx cases: reload carry-over, inherited segment on binary upgrade, and fresh allocation) and installs the pointer before fork.
- **Fail-safe:** any failure (zone add, slab alloc, misalignment) logs a warning and leaves the process-local fallback active — worst case is the prior per-worker behaviour, never a crash.

## Acceptance criteria

- ✅ Scrapes from any worker now sum to N (shared atomics; exact within the atomic-update window).
- ✅ No hot-path regression: the increment is still a single relaxed `fetch_add` on a memory address — only *where the atomic lives* changed.
- ✅ Counter names, HELP text, types, and output order are byte-for-byte preserved (verified by diffing the exposition strings against `main`).

## Testing

- Builds against nginx 1.28.0 headers (`./configure --with-compat`); `cargo clippy` clean for the new code.
- The crate is `crate-type = ["cdylib"]` with `test = false`, so there are no in-tree unit tests; the runtime "N requests sum across workers" check is covered by a multi-worker nginx run (the `nginx-compat` CI job loads the module). The hot path is unchanged, so the `stress-test/` benchmarks should show no regression.