### PR TITLE
fix: make Docker image generic so it starts without the demo gRPC server (#120)

### DIFF
--- a/.github/workflows/nginx-compat.yml
+++ b/.github/workflows/nginx-compat.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Verify module loads
         run: |
           echo "Testing nginx -t (config validation with module loaded)..."
+          # No --add-host: the generic image must start without the demo gRPC
+          # backend being resolvable (issue #120).
           docker run --rm \
-            --add-host=grpc-content-server:127.0.0.1 \
             -e LN_CLIENT_TYPE=LNURL \
             -e LNURL_ADDRESS=hello@getalby.com \
             -e ROOT_KEY=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4 \
@@ -52,8 +53,8 @@ jobs:
       - name: Smoke test - module serves requests
         run: |
           echo "Starting container for smoke test..."
+          # No --add-host: verifies the image boots standalone (issue #120).
           docker run -d --name smoke-test-${{ matrix.nginx_version }} \
-            --add-host=grpc-content-server:127.0.0.1 \
             -p 8000:8000 \
             -e LN_CLIENT_TYPE=LNURL \
             -e LNURL_ADDRESS=hello@getalby.com \

--- a/.github/workflows/nginx-compat.yml
+++ b/.github/workflows/nginx-compat.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           echo "Testing nginx -t (config validation with module loaded)..."
           # No --add-host: the generic image must start without the demo gRPC
-          # backend being resolvable (issue #120).
+          # backend being resolvable.
           docker run --rm \
             -e LN_CLIENT_TYPE=LNURL \
             -e LNURL_ADDRESS=hello@getalby.com \
@@ -53,7 +53,7 @@ jobs:
       - name: Smoke test - module serves requests
         run: |
           echo "Starting container for smoke test..."
-          # No --add-host: verifies the image boots standalone (issue #120).
+          # No --add-host: verifies the image boots standalone.
           docker run -d --name smoke-test-${{ matrix.nginx_version }} \
             -p 8000:8000 \
             -e LN_CLIENT_TYPE=LNURL \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,7 +261,7 @@ services:
     depends_on:
       # NOTE: intentionally NOT depending on grpc-content-server — that is a
       # demo-only backend and the LNURL Lightning service must not be coupled to
-      # it (issue #120). Bring up grpc-content-server explicitly when you want
+      # it. Bring up grpc-content-server explicitly when you want
       # to exercise the /content.ContentService/ demo route.
       - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,8 +259,11 @@ services:
     volumes:
       - cashu-data:/app/data
     depends_on:
+      # NOTE: intentionally NOT depending on grpc-content-server — that is a
+      # demo-only backend and the LNURL Lightning service must not be coupled to
+      # it (issue #120). Bring up grpc-content-server explicitly when you want
+      # to exercise the /content.ContentService/ demo route.
       - redis
-      - grpc-content-server
 
   nginx-cln:
     container_name: nginx-cln

--- a/nginx.conf
+++ b/nginx.conf
@@ -48,7 +48,7 @@ http {
         #
         # This route proxies to `grpc-content-server`, a demo backend that only
         # exists inside this project's docker-compose stack. To keep the
-        # published image generic and able to start standalone (issue #120), the
+        # published image generic and able to start standalone, the
         # backend is referenced through a variable so nginx defers DNS
         # resolution to request time. Without the variable, nginx resolves the
         # hostname at startup and the whole server fails to boot when the demo

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,10 +30,12 @@ http {
 
     #include /etc/nginx/conf.d/*.conf;
 
-    # Define upstream for gRPC server
-    upstream grpc-content-server {
-        server grpc-content-server:50051;
-    }
+    # DNS resolver used to look up proxied/gRPC backends lazily at request time
+    # instead of at startup. 127.0.0.11 is Docker's embedded DNS, available on
+    # any user-defined Docker network (e.g. docker-compose). Standalone runs
+    # never resolve the demo backend below, so an unreachable resolver here is
+    # harmless — nginx only contacts it when the gRPC demo route is actually hit.
+    resolver 127.0.0.11 ipv6=off valid=30s;
 
     server {
         # Enable HTTP/2 for gRPC support
@@ -42,15 +44,26 @@ http {
         http2 on;
         server_name _;
 
-        # L402 protection for gRPC endpoints
+        # L402 protection for gRPC endpoints.
+        #
+        # This route proxies to `grpc-content-server`, a demo backend that only
+        # exists inside this project's docker-compose stack. To keep the
+        # published image generic and able to start standalone (issue #120), the
+        # backend is referenced through a variable so nginx defers DNS
+        # resolution to request time. Without the variable, nginx resolves the
+        # hostname at startup and the whole server fails to boot when the demo
+        # backend is absent. Standalone, this route returns 502 (the rest of the
+        # config still works); in docker-compose it resolves normally.
         location /content.ContentService/ {
             # l402 module directives:
             l402    on;
             l402_amount_msat_default    10000;
             l402_macaroon_timeout 0;  # Macaroon validity in seconds, set to 0 to disable timeout
 
-            # Proxy directly to gRPC server without rewrite
-            grpc_pass grpc://grpc-content-server;
+            # Proxy directly to gRPC server without rewrite. Variable form =>
+            # lazy, request-time resolution via the `resolver` defined above.
+            set $grpc_content_backend grpc-content-server:50051;
+            grpc_pass grpc://$grpc_content_backend;
         }
 
         location / {


### PR DESCRIPTION
## Problem

The published image (`ghcr.io/dhananjaypurohit/ngx_l402:latest`) fails to start when run standalone as documented in the Quick Start. `nginx.conf` baked a static upstream pointing at `grpc-content-server:50051` — a demo backend that only exists inside this repo's `docker-compose.yml`. nginx resolves upstream server hostnames **at startup**, so when that backend is absent nginx never boots. The CI compat job worked around this with `--add-host=grpc-content-server:127.0.0.1`.

Additionally, `nginx-lnurl` had `depends_on: grpc-content-server`, coupling an unrelated Lightning backend to a demo-only service.

## Fix

- **`nginx.conf`**: removed the static `upstream grpc-content-server` block. Added a `resolver` and referenced the demo backend through a variable in `grpc_pass` (`set $grpc_content_backend …; grpc_pass grpc://$grpc_content_backend;`). The variable form defers DNS resolution to **request time**, so nginx starts even when the backend can't be resolved. Standalone, the demo route returns 502; in docker-compose it resolves normally via Docker's embedded DNS.
- **`docker-compose.yml`**: removed `depends_on: grpc-content-server` from `nginx-lnurl`.
- **`.github/workflows/nginx-compat.yml`**: dropped the two `--add-host` workarounds — the compat job now verifies the image boots standalone.

## Verification

- `nginx -t` on the isolated `resolver` + variable `grpc_pass` pattern passes **without** `grpc-content-server` being resolvable, confirming standalone startup.
- The existing gRPC integration test (`tests.yml`) still passes: the L402 access handler returns the 402 challenge before the upstream is ever contacted, and the valid-credentials gRPC test (which needs the backend) is brought up explicitly alongside `grpc-content-server`.

Fixes #120.