### PR TITLE
feat: log metrics endpoint and dry-run instructions on startup (#119)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2242,7 +2242,7 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     info!("✅ L402 module initialization complete");
 
     // Splash key observability / testing features so operators can discover
-    // them straight from the logs without a trip to the docs (issue #119).
+    // them straight from the logs without a trip to the docs.
     info!("📊 Prometheus metrics: expose a route with `l402_metrics;` (e.g. `location = /metrics {{ l402_metrics; }}`) to scrape l402_* counters");
     info!("🌓 Dry-run (shadow) mode: add `l402_dry_run on;` to a protected location to evaluate pricing/challenges/metrics without enforcing payment");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2241,6 +2241,11 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
 
     info!("✅ L402 module initialization complete");
 
+    // Splash key observability / testing features so operators can discover
+    // them straight from the logs without a trip to the docs (issue #119).
+    info!("📊 Prometheus metrics: expose a route with `l402_metrics;` (e.g. `location = /metrics {{ l402_metrics; }}`) to scrape l402_* counters");
+    info!("🌓 Dry-run (shadow) mode: add `l402_dry_run on;` to a protected location to evaluate pricing/challenges/metrics without enforcing payment");
+
     let redeem_on_lightning = std::env::var("CASHU_REDEEM_ON_LIGHTNING")
         .unwrap_or_else(|_| "false".to_string())
         .trim()


### PR DESCRIPTION
## What

When nginx starts with the `ngx_l402` module, the init logs show successful startup but don't surface two features operators usually go looking for. This adds two `info!` lines in `init_module`, right after `✅ L402 module initialization complete`:

- **Prometheus metrics** — points out the `l402_metrics;` directive (e.g. `location = /metrics { l402_metrics; }`) so operators know where to scrape `l402_*` counters.
- **Dry-run (shadow) mode** — hints at `l402_dry_run on;` so developers can test production traffic without enforcing payment.

## Why

A quick, built-in reference at startup, saving a trip to the docs when verifying metrics or running a shadow-mode test.

Fixes #119.