### PR TITLE
docs: dual GitHub + Nostr PR workflow and org migration reference updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing to ngx_l402! This guide will help yo
 - [Coding Standards](#coding-standards)
 - [Testing Guidelines](#testing-guidelines)
 - [Performance Testing](#performance-testing)
+- [Submitting a Pull Request (GitHub + Nostr)](#submitting-a-pull-request-github--nostr)
 - [Pull Request Process](#pull-request-process)
 - [Architecture Guidelines](#architecture-guidelines)
 
@@ -49,7 +50,7 @@ We welcome various types of contributions:
 
 ### Finding Issues to Work On
 
-- Browse [open issues](https://github.com/DhananjayPurohit/ngx_l402/issues)
+- Browse [open issues](https://github.com/ngx-l402/ngx-l402/issues)
 - Look for `good-first-issue` or `help-wanted` labels if you are new.
 - Check performance optimization issues (especially post-stress testing)
 - Improve areas where documentation is unclear
@@ -290,6 +291,87 @@ Example PR description:
 
 ---
 
+## Submitting a Pull Request (GitHub + Nostr)
+
+This project is hosted on **both GitHub and [Nostr](https://gitworkshop.dev)**.
+
+**First PR? Just pick whichever door you already know. Contributing regularly? Please post
+to both.** Don't let the dual setup stop you from contributing — a PR on either side is
+always welcome, and maintainers will bridge the gap when needed.
+
+| | GitHub (classic) | Nostr (ngit) |
+|---|---|---|
+| Need an account | GitHub account | Nostr keypair (nsec) |
+| Fork required | Yes | No |
+| CI runs automatically | Yes | After a maintainer mirrors it |
+
+### Option A — GitHub (easiest if you already have a GitHub account)
+
+```bash
+# Fork + clone (origin = your fork, upstream = this repo)
+gh repo fork ngx-l402/ngx-l402 --clone
+cd ngx-l402
+
+git checkout -b fix/my-change
+# ...make changes, commit...
+git push -u origin fix/my-change
+
+gh pr create --repo ngx-l402/ngx-l402 --base main \
+  --title "fix: my change" --body "what and why"
+```
+
+### Option B — Nostr (no fork, no GitHub account needed)
+
+```bash
+# One-time: install ngit and log in with your Nostr identity
+curl -Ls https://ngit.dev/install.sh | bash
+ngit login
+
+# Clone straight from Nostr (clone URL is on the gitworkshop.dev repo page)
+git clone nostr://npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402
+cd ngx-l402
+
+# Branch MUST use the pr/ prefix
+git checkout -b pr/my-change
+# ...make changes, commit...
+
+# This push IS the PR — it publishes a proposal to gitworkshop.dev
+git push -o 'title=fix: my change' -o 'description=what and why' -u origin pr/my-change
+```
+
+### Option C — both (preferred for regular contributors)
+
+Do the GitHub setup from Option A, then add the Nostr remote once:
+
+```bash
+git remote add nostr nostr://npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402
+```
+
+Then, from a single `pr/`-prefixed branch, push to both:
+
+```bash
+git checkout -b pr/my-change
+# ...make changes, commit...
+
+# 1) GitHub PR
+git push -u origin pr/my-change
+gh pr create --repo ngx-l402/ngx-l402 --base main \
+  --title "fix: my change" --body "what and why"
+
+# 2) Nostr PR — same branch, same title/description
+git push -o 'title=fix: my change' -o 'description=what and why' nostr pr/my-change
+```
+
+Use identical title and description on both, and link each PR to the other in its
+description. **To revise after review**, commit and push the branch again to both remotes —
+both PRs update in place.
+
+> **Maintainers:** merge locally with `git merge --no-ff` and push `main` through the Nostr
+> remote — never use GitHub's squash/merge button. Preserving the original commit SHAs is
+> what lets both the GitHub PR and the Nostr proposal close themselves automatically.
+
+---
+
 ## Pull Request Process
 
 ### Pre-Submission Checklist
@@ -337,7 +419,7 @@ Closes #issue_number
 2. **Maintainer review**: Code quality, design, safety
 3. **Discussion**: Address feedback and questions
 4. **Approval**: One maintainer approval required
-5. **Merge**: Squash and merge to `main`
+5. **Merge**: Merged to `main` preserving commits (`git merge --no-ff`), so both the GitHub PR and Nostr proposal close automatically
 
 ### After Your PR is Merged
 
@@ -398,7 +480,7 @@ When adding features, consider:
 ## Getting Help
 
 - 📖 **Documentation**: See [README.md](README.md)
-- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/DhananjayPurohit/ngx_l402/issues)
+- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/ngx-l402/ngx-l402/issues)
 - 📚 **Learning Resources**:
   - [Rust Book](https://doc.rust-lang.org/book/)
   - [L402 Protocol](https://docs.lightning.engineering/the-lightning-network/l402)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run -d \
   -e LN_CLIENT_TYPE=LNURL \
   -e LNURL_ADDRESS=username@your-lnurl-server.com \
   -e ROOT_KEY=$(openssl rand -hex 32) \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 Test it:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ Report privately using one of the following, in order of preference:
 
 1. **GitHub Private Vulnerability Reporting** (preferred)
    Open a report at
-   <https://github.com/DhananjayPurohit/ngx_l402/security/advisories/new>.
+   <https://github.com/ngx-l402/ngx-l402/security/advisories/new>.
    This keeps the report visible only to maintainers and lets us coordinate
    a fix and advisory in the same place.
 2. **Direct contact with the maintainer**

--- a/docs/building.md
+++ b/docs/building.md
@@ -30,8 +30,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/DhananjayPurohit/ngx_l402.git
-cd ngx_l402
+git clone https://github.com/ngx-l402/ngx-l402.git
+cd ngx-l402
 ```
 
 2. Download Nginx source and build the module:

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ docker run -d \
   -e LN_CLIENT_TYPE=LNURL \
   -e LNURL_ADDRESS=username@your-lnurl-server.com \
   -e ROOT_KEY=your-32-byte-hex-key \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 Then test it:

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -3,7 +3,7 @@
 The easiest way to deploy the L402 Nginx module is with our official Docker images.
 
 ```bash
-docker pull ghcr.io/dhananjaypurohit/ngx_l402:latest
+docker pull ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ---
@@ -19,7 +19,7 @@ docker run -d \
   -e LN_CLIENT_TYPE=LNURL \
   -e LNURL_ADDRESS=username@your-lnurl-server.com \
   -e ROOT_KEY=your-32-byte-hex-key \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 2. LND Backend with Cashu Support
@@ -43,7 +43,7 @@ docker run -d \
   -e CASHU_REDEEM_ON_LIGHTNING=true \
   -e REDIS_URL=redis://redis:6379 \
   -v ~/l402-data:/app/data \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 3. LND via Lightning Node Connect (LNC)
@@ -59,7 +59,7 @@ docker run -d \
   -e LNC_PAIRING_PHRASE="word1 word2 word3 word4 word5 word6 word7 word8 word9 word10" \
   -e LNC_MAILBOX_SERVER=mailbox.terminal.lightning.today:443 \
   -e ROOT_KEY=your-32-byte-hex-key \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 4. CLN Backend (Core Lightning)
@@ -75,7 +75,7 @@ docker run -d \
   -e CASHU_WALLET_MNEMONIC="word1 word2 ... word12" \
   -e CASHU_DB_PATH=/app/data/cashu_tokens.db \
   -v ~/.lightning/bitcoin/lightning-rpc:/app/data/lightning-rpc:ro \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 5. NWC Backend (Nostr Wallet Connect)
@@ -87,7 +87,7 @@ docker run -d \
   -e LN_CLIENT_TYPE=NWC \
   -e NWC_URI=nostr+walletconnect://your-pubkey?relay=wss://relay.damus.io&secret=your-secret \
   -e ROOT_KEY=your-32-byte-hex-key \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 6. High-Performance P2PK Mode (Recommended for Production)
@@ -109,7 +109,7 @@ docker run -d \
   -e CASHU_REDEEM_ON_LIGHTNING=true \
   -e REDIS_URL=redis://redis:6379 \
   -v ~/l402-data:/app/data \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 7. BOLT12 Backend (Reusable Offers)
@@ -123,7 +123,7 @@ docker run -d \
   -e CLN_LIGHTNING_RPC_FILE_PATH=/app/data/lightning-rpc \
   -e ROOT_KEY=your-32-byte-hex-key \
   -v ~/.lightning/bitcoin/lightning-rpc:/app/data/lightning-rpc:ro \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ### 8. Eclair Backend
@@ -136,7 +136,7 @@ docker run -d \
   -e ECLAIR_ADDRESS=http://your-eclair-node:8282 \
   -e ECLAIR_PASSWORD=your-eclair-password \
   -e ROOT_KEY=your-32-byte-hex-key \
-  ghcr.io/dhananjaypurohit/ngx_l402:latest
+  ghcr.io/ngx-l402/ngx-l402:latest
 ```
 
 ---
@@ -178,5 +178,8 @@ docker stop l402-nginx
 ## Specific Versions
 
 ```bash
+docker pull ghcr.io/ngx-l402/ngx-l402:v1.2.8
+
+# Releases up to v1.2.7 were published under the previous namespace:
 docker pull ghcr.io/dhananjaypurohit/ngx_l402:v1.2.5
 ```

--- a/docs/install-manual.md
+++ b/docs/install-manual.md
@@ -6,7 +6,7 @@
 
 ### 1. Download the Module
 
-Download `libngx_l402_lib.so` from the [latest release](https://github.com/DhananjayPurohit/ngx_l402/releases/latest) and copy it to your Nginx modules directory:
+Download `libngx_l402_lib.so` from the [latest release](https://github.com/ngx-l402/ngx-l402/releases/latest) and copy it to your Nginx modules directory:
 
 ```bash
 sudo cp libngx_l402_lib.so /etc/nginx/modules/

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -13,8 +13,8 @@ This guide is for contributors running `ngx_l402` locally on macOS.
 ## 2. Clone and enter the repository
 
 ```bash
-git clone https://github.com/DhananjayPurohit/ngx_l402.git
-cd ngx_l402
+git clone https://github.com/ngx-l402/ngx-l402.git
+cd ngx-l402
 ```
 
 ## 3. Start the stack

--- a/src/payment_page.rs
+++ b/src/payment_page.rs
@@ -286,7 +286,7 @@ document.getElementById('preimage-section').classList.remove('hidden')\">Enter p
   </div>
   {cashu_tab_html}
   <div class="footer">
-    Secured by <a href="https://github.com/DhananjayPurohit/ngx_l402" target="_blank" rel="noopener">ngx_l402</a> &#183; L402 Protocol
+    Secured by <a href="https://github.com/ngx-l402/ngx-l402" target="_blank" rel="noopener">ngx_l402</a> &#183; L402 Protocol
   </div>
 </div>
 <script>


### PR DESCRIPTION
Documents the GitHub + Nostr contribution paths in CONTRIBUTING.md and updates every repo URL and ghcr image path after the move to the ngx-l402 org.