### PR TITLE
docs: fix broken documentation links after org migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ For local contributor setup on macOS (Docker nginx recommended), see `docs/macos
 
 ## 📖 Documentation
 
-**Full documentation is available at: https://dhananjaypurohit.github.io/ngx_l402/**
+**Full documentation is available at: https://ngx-l402.org/docs/**
 
-- [Installation](https://dhananjaypurohit.github.io/ngx_l402/install-manual.html)
-- [Docker Setup](https://dhananjaypurohit.github.io/ngx_l402/install-docker.html)
-- [Configuration & Environment Variables](https://dhananjaypurohit.github.io/ngx_l402/config-env-vars.html)
-- [Cashu eCash Support](https://dhananjaypurohit.github.io/ngx_l402/cashu.html)
-- [Multi-Tenant](https://dhananjaypurohit.github.io/ngx_l402/config-multi-tenant.html)
-- [Dry-Run (Shadow) Mode](https://dhananjaypurohit.github.io/ngx_l402/dry-run.html)
-- [Building from Source](https://dhananjaypurohit.github.io/ngx_l402/building.html)
+- [Installation](https://ngx-l402.org/docs/install-manual.html)
+- [Docker Setup](https://ngx-l402.org/docs/install-docker.html)
+- [Configuration & Environment Variables](https://ngx-l402.org/docs/config-env-vars.html)
+- [Cashu eCash Support](https://ngx-l402.org/docs/cashu.html)
+- [Multi-Tenant](https://ngx-l402.org/docs/config-multi-tenant.html)
+- [Dry-Run (Shadow) Mode](https://ngx-l402.org/docs/dry-run.html)
+- [Building from Source](https://ngx-l402.org/docs/building.html)
 
 ---
 


### PR DESCRIPTION
All 8 links in the README's Documentation section still point to the old org's GitHub Pages site, which has been 404ing since the org move. I swapped the domain to `https://ngx-l402.org/docs/`, where `docs.yml` now syncs the built docs. Page paths are unchanged, and I checked all 8 replacements: they return 200. Docs only, no code touched.

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402/prs/nevent1qy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqgplsak7je4wmz24qten6hftd9k7a4efvysc26y8elja5hhchepu5vqkyjl3)

Closes #149