### PR TITLE
ci: add cargo fmt --check lint gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check

--- a/ngx_l402_core/src/l402_header.rs
+++ b/ngx_l402_core/src/l402_header.rs
@@ -4,8 +4,18 @@
 /// `WWW-Authenticate` header value of the form:
 ///   `L402 macaroon="<b64>", invoice="<bolt11>"`
 pub fn parse_l402_header_value(header: &str) -> Option<(String, String)> {
-    let mac = header.split("macaroon=\"").nth(1)?.split('"').next()?.to_string();
-    let inv = header.split("invoice=\"").nth(1)?.split('"').next()?.to_string();
+    let mac = header
+        .split("macaroon=\"")
+        .nth(1)?
+        .split('"')
+        .next()?
+        .to_string();
+    let inv = header
+        .split("invoice=\"")
+        .nth(1)?
+        .split('"')
+        .next()?
+        .to_string();
     Some((mac, inv))
 }
 

--- a/ngx_l402_core/src/p2pk.rs
+++ b/ngx_l402_core/src/p2pk.rs
@@ -84,7 +84,7 @@ mod tests {
         assert!(parse_p2pk_secret_key("").is_err());
         assert!(parse_p2pk_secret_key("xyz").is_err());
         assert!(parse_p2pk_secret_key("01").is_err()); // too short
-        // Zero scalar is not a valid secp256k1 secret key.
+                                                       // Zero scalar is not a valid secp256k1 secret key.
         assert!(parse_p2pk_secret_key(
             "0000000000000000000000000000000000000000000000000000000000000000"
         )

--- a/ngx_l402_core/src/wallet_seed.rs
+++ b/ngx_l402_core/src/wallet_seed.rs
@@ -104,7 +104,10 @@ mod tests {
 
     #[test]
     fn seed_is_64_bytes() {
-        assert_eq!(derive_wallet_seed(VECTOR_MNEMONIC).unwrap().len(), WALLET_SEED_LEN);
+        assert_eq!(
+            derive_wallet_seed(VECTOR_MNEMONIC).unwrap().len(),
+            WALLET_SEED_LEN
+        );
     }
 
     #[test]
@@ -165,7 +168,10 @@ mod tests {
     /// Fresh mnemonics must not repeat — proves the RNG is actually exercised.
     #[test]
     fn generated_mnemonics_are_unique() {
-        assert_ne!(generate_mnemonic(12).unwrap(), generate_mnemonic(12).unwrap());
+        assert_ne!(
+            generate_mnemonic(12).unwrap(),
+            generate_mnemonic(12).unwrap()
+        );
     }
 
     #[test]
@@ -193,8 +199,7 @@ mod tests {
     #[test]
     fn distinct_seeds_have_distinct_fingerprints() {
         let a = derive_wallet_seed(VECTOR_MNEMONIC).unwrap();
-        let other =
-            "legal winner thank year wave sausage worth useful legal winner thank yellow";
+        let other = "legal winner thank year wave sausage worth useful legal winner thank yellow";
         let b = derive_wallet_seed(other).unwrap();
         assert_ne!(wallet_fingerprint(&a), wallet_fingerprint(&b));
     }

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -4,6 +4,7 @@ use cdk;
 use cdk::mint_url::MintUrl;
 use hex;
 use l402_middleware::lnclient;
+use l402_middleware::lndrpc::lnrpc;
 use log::{debug, error, info, warn};
 use redis::Commands;
 use sha2::{Digest, Sha256};
@@ -12,7 +13,6 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
-use l402_middleware::lndrpc::lnrpc;
 use url::Url;
 
 // Thread-local storage to track processed tokens
@@ -192,7 +192,12 @@ fn wallet_mnemonic_file_path(db_url: &str) -> Option<String> {
         .trim_start_matches("sqlite://")
         .trim_start_matches("sqlite:");
     let parent = std::path::Path::new(raw).parent()?;
-    Some(parent.join("wallet.mnemonic").to_string_lossy().into_owned())
+    Some(
+        parent
+            .join("wallet.mnemonic")
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Persist the mnemonic to `path` with owner-only permissions where supported.
@@ -216,8 +221,7 @@ fn get_cached_seed() -> [u8; 64] {
         // Derivation lives in ngx_l402_core so it can be unit-tested (golden
         // vectors) without nginx. The mnemonic was validated at init, so this
         // cannot fail here.
-        ngx_l402_core::derive_wallet_seed(mnemonic)
-            .expect("wallet mnemonic was validated at init")
+        ngx_l402_core::derive_wallet_seed(mnemonic).expect("wallet mnemonic was validated at init")
     })
 }
 
@@ -509,22 +513,28 @@ pub async fn restore_wallets_state() {
         // block the nginx worker process or produce alarming ERROR logs.
         // Restoration is best-effort — missed proofs will be recovered
         // on the next redemption or sweep cycle.
-        let restore_result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            async {
-                match cdk::wallet::Wallet::new(mint_url, unit, db.clone(), seed, None) {
-                    Ok(wallet) => wallet.restore().await
-                        .map(|amount| { let v: u64 = amount.into(); v })
-                        .map_err(|e| e.to_string()),
-                    Err(e) => Err(e.to_string()),
-                }
+        let restore_result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            match cdk::wallet::Wallet::new(mint_url, unit, db.clone(), seed, None) {
+                Ok(wallet) => wallet
+                    .restore()
+                    .await
+                    .map(|amount| {
+                        let v: u64 = amount.into();
+                        v
+                    })
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e.to_string()),
             }
-        ).await;
+        })
+        .await;
 
         match restore_result {
             Ok(Ok(amount)) => info!("✅ Restored {} sats state from {}", amount, mint_url),
-            Ok(Err(e))     => warn!("⚠️ Skipping restore for {} (mint error): {}", mint_url, e),
-            Err(_)         => warn!("⚠️ Skipping restore for {} (unreachable, timed out after 5s)", mint_url),
+            Ok(Err(e)) => warn!("⚠️ Skipping restore for {} (mint error): {}", mint_url, e),
+            Err(_) => warn!(
+                "⚠️ Skipping restore for {} (unreachable, timed out after 5s)",
+                mint_url
+            ),
         }
     }
 }
@@ -576,7 +586,10 @@ pub async fn reconcile_pending_proofs() {
                 mint_url, reclaimable
             ),
             Ok(Ok(_)) => debug!("✅ No pending proofs to reconcile for {}", mint_url),
-            Ok(Err(e)) => warn!("⚠️ Pending-proof reconciliation failed for {}: {}", mint_url, e),
+            Ok(Err(e)) => warn!(
+                "⚠️ Pending-proof reconciliation failed for {}: {}",
+                mint_url, e
+            ),
             Err(_) => warn!(
                 "⚠️ Pending-proof reconciliation timed out for {} (mint unreachable)",
                 mint_url
@@ -927,7 +940,10 @@ pub async fn verify_cashu_token(
                         }
                     }
                     Err(e) => {
-                        warn!("⚠️ Failed to extract proofs from token for lnurl mapping: {}", e);
+                        warn!(
+                            "⚠️ Failed to extract proofs from token for lnurl mapping: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -949,7 +965,10 @@ pub async fn verify_cashu_token(
                     Ok(false)
                 }
                 Err(e) => {
-                    warn!("⚠️ Redis claim failed, admitting (fail-open, mint-backstopped): {}", e);
+                    warn!(
+                        "⚠️ Redis claim failed, admitting (fail-open, mint-backstopped): {}",
+                        e
+                    );
                     cache_processed_token(token);
                     Ok(true)
                 }
@@ -1157,7 +1176,10 @@ pub async fn verify_cashu_token_p2pk(
         };
         verify_proof_dleq_offline(proof, amount_key, require_dleq)?;
     }
-    info!("✅ All {} proofs passed NUT-12 DLEQ verification", proofs.len());
+    info!(
+        "✅ All {} proofs passed NUT-12 DLEQ verification",
+        proofs.len()
+    );
 
     // NUT-07: check proof state with the mint before accepting.
     // Without this call, a proof that has already been spent at the mint would
@@ -1240,7 +1262,10 @@ pub async fn verify_cashu_token_p2pk(
             // Fail closed — refuse the token until Redis recovers — matching the
             // preimage path's outage policy. The proofs are not stored, so a
             // legitimate retry after recovery still succeeds.
-            error!("❌ Redis unavailable for Cashu P2PK claim — rejecting to prevent replay: {}", e);
+            error!(
+                "❌ Redis unavailable for Cashu P2PK claim — rejecting to prevent replay: {}",
+                e
+            );
             return Err(format!(
                 "Redis unavailable; refusing Cashu token to prevent replay: {}",
                 e
@@ -1373,10 +1398,7 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
         let total_amount: u64 = match wallet_clone.total_balance().await {
             Ok(balance) => balance.into(),
             Err(e) => {
-                let msg = format!(
-                    "⚠️ Failed to get total balance for {}: {}",
-                    mint_url_str, e
-                );
+                let msg = format!("⚠️ Failed to get total balance for {}: {}", mint_url_str, e);
                 warn!("{}", msg);
                 cashu_redemption_logger::log_redemption(&msg);
                 continue;
@@ -1933,8 +1955,7 @@ mod tests {
     const VALID_PROOF_JSON: &str = r#"{"amount": 1,"id": "00882760bfa2eb41","secret": "daf4dd00a2b68a0858a80450f52c8a7d2ccf87d375e43e216e0c571f089f63e9","C": "024369d2d22a80ecf78f3937da9d5f30c1b9f74f0c32684d583cca0fa6a61cdcfc","dleq": {"e": "b31e58ac6527f34975ffab13e70a48b6d2b0d35abc4b03f0151f09ee1a9763d4","s": "8fbae004c59e754d71df67e392b6ae4e29293113ddc2ec86592a0431d16306d8","r": "a6d13fcd7a18442e6076f5e1e7c887ad5de40a019824bdfa9fe740d302e8d861"}}"#;
 
     // The mint public key `A` that signed the proof above.
-    const MINT_KEY_HEX: &str =
-        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const MINT_KEY_HEX: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
     fn mint_key() -> PublicKey {
         PublicKey::from_str(MINT_KEY_HEX).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use env_logger;
 use hex;
+use l402_middleware::lndrpc::lnrpc;
 use l402_middleware::middleware::L402Middleware;
 use l402_middleware::{bolt12, cln, eclair, l402, lnclient, lnd, lnurl, macaroon_util, nwc, utils};
 use log::{debug, error, info, warn};
@@ -9,17 +10,16 @@ use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_chain_t, ngx_command_t, ngx_conf_t, ngx_cycle_s,
     ngx_http_discard_request_body, ngx_http_handler_pt, ngx_http_module_t,
     ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_log_s, ngx_module_t,
-    ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc, ngx_slab_pool_t,
-    ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_COPY,
-    NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK,
-    NGX_HTTP_LOC_CONF, NGX_HTTP_LOC_CONF_OFFSET, NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE,
+    ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc, ngx_slab_pool_t, ngx_str_t, ngx_uint_t,
+    NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE,
+    NGX_HTTP_GET, NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK, NGX_HTTP_LOC_CONF,
+    NGX_HTTP_LOC_CONF_OFFSET, NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE,
     NGX_HTTP_NOT_ALLOWED, NGX_HTTP_OPTIONS, NGX_HTTP_PATCH, NGX_HTTP_POST, NGX_HTTP_PROPFIND,
     NGX_HTTP_PROPPATCH, NGX_HTTP_PUT, NGX_HTTP_SRV_CONF, NGX_HTTP_TRACE, NGX_HTTP_UNLOCK,
-    NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_WARN, NGX_OK,
-    NGX_RS_MODULE_SIGNATURE,
+    NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_WARN, NGX_OK, NGX_RS_MODULE_SIGNATURE,
 };
 use ngx::http::{
-    HttpModule, HttpModuleLocationConf, HttpModuleMainConf, HttpModuleServerConf, HTTPStatus,
+    HTTPStatus, HttpModule, HttpModuleLocationConf, HttpModuleMainConf, HttpModuleServerConf,
     Merge, MergeConfigError, NgxHttpCoreModule, Request,
 };
 use ngx::{ngx_log_error, ngx_string};
@@ -35,7 +35,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use l402_middleware::lndrpc::lnrpc;
 
 mod cashu;
 mod cashu_redemption_logger;
@@ -291,7 +290,10 @@ fn handle_preimage_claim(result: Result<bool, ReplayClaimError>) -> isize {
             NGX_DECLINED as isize
         }
         Err(ReplayClaimError::Unavailable(e)) => {
-            error!("❌ Redis unavailable for preimage claim — rejecting to prevent replay: {}", e);
+            error!(
+                "❌ Redis unavailable for preimage claim — rejecting to prevent replay: {}",
+                e
+            );
             503
         }
     }
@@ -416,13 +418,19 @@ pub fn release_cashu_token(token: &str) {
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(e) => {
-            warn!("⚠️ Could not release Cashu replay claim (no Redis conn): {}", e);
+            warn!(
+                "⚠️ Could not release Cashu replay claim (no Redis conn): {}",
+                e
+            );
             return;
         }
     };
     let redis_key = cashu_token_redis_key(token);
     if let Err(e) = redis::cmd("DEL").arg(&redis_key).query::<i64>(&mut *conn) {
-        warn!("⚠️ Failed to release Cashu replay claim {}: {}", redis_key, e);
+        warn!(
+            "⚠️ Failed to release Cashu replay claim {}: {}",
+            redis_key, e
+        );
     }
 }
 
@@ -463,7 +471,10 @@ pub fn cache_settled_preimage(payment_hash: &[u8], preimage: &[u8]) -> Result<()
     conn.set_ex::<_, _, ()>(&redis_key, preimage_hex, ttl_seconds)
         .map_err(|e| format!("Failed to cache settled preimage: {}", e))?;
 
-    info!("✅ Cached settled preimage for payment_hash {}", &hash_hex[..16]);
+    info!(
+        "✅ Cached settled preimage for payment_hash {}",
+        &hash_hex[..16]
+    );
     Ok(())
 }
 
@@ -486,7 +497,7 @@ pub fn extract_payment_hash_from_auth_str(auth_str: &str) -> Result<Vec<u8>, Str
         .map_err(|e| format!("Failed to deserialize macaroon: {}", e))?;
 
     // The identifier holds the raw payment-hash bytes (usually 32 bytes).
-    // We extract the raw hash here for the node lookup by stripping the leading 
+    // We extract the raw hash here for the node lookup by stripping the leading
     // 0xff sentinel if the identifier length is 33 bytes.
     let id_bytes = mac.identifier().0.clone();
 
@@ -502,7 +513,7 @@ pub fn extract_payment_hash_from_auth_str(auth_str: &str) -> Result<Vec<u8>, Str
             .copied()
             .skip_while(|&b| b == 0xff)
             .collect();
-        
+
         if stripped.len() == 32 {
             stripped
         } else {
@@ -954,7 +965,8 @@ impl HttpModule for L402Module {
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
         info!("🚀 Initializing L402 module handler");
-        let cmcf: *mut ngx::ffi::ngx_http_core_main_conf_t = NgxHttpCoreModule::main_conf_mut(&*cf).expect("http core main conf") as *mut _;
+        let cmcf: *mut ngx::ffi::ngx_http_core_main_conf_t =
+            NgxHttpCoreModule::main_conf_mut(&*cf).expect("http core main conf") as *mut _;
         let h = ngx_array_push(
             &mut (*cmcf).phases[ngx_http_phases_NGX_HTTP_ACCESS_PHASE as usize].handlers,
         ) as *mut ngx_http_handler_pt;
@@ -1152,7 +1164,8 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 12] = [
     },
     ngx_command_t {
         name: ngx_string!("l402_auto_detect_payment"),
-        type_: (NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
+        type_: (NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1)
+            as ngx_uint_t,
         set: Some(ngx_http_l402_auto_detect_payment_set),
         conf: NGX_HTTP_LOC_CONF_OFFSET,
         offset: 0,
@@ -1286,7 +1299,6 @@ impl Merge for ModuleConfig {
     }
 }
 
-
 /// Map nginx's `r->method` bitmask to the canonical uppercase string used in
 /// the `RequestMethod` macaroon caveat. Falls back to `"UNKNOWN"` for methods
 /// nginx didn't recognise; both sides of the protocol see the same fallback,
@@ -1359,7 +1371,6 @@ unsafe fn send_html_response(r: *mut ngx_http_request_t, status: u16, body: Stri
 
     unsafe { req.output_filter(&mut *chain).0 as isize }
 }
-
 
 // Per-worker scratch slot used by `l402_access_handler` to report *which*
 // payment method satisfied a successful verification. The wrapper consumes it
@@ -1574,9 +1585,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                 Some(PaymentMethod::Lightning) => {
                     metrics::inc(metrics::Metric::PaymentsLightningTotal)
                 }
-                Some(PaymentMethod::Cashu) => {
-                    metrics::inc(metrics::Metric::PaymentsCashuTotal)
-                }
+                Some(PaymentMethod::Cashu) => metrics::inc(metrics::Metric::PaymentsCashuTotal),
                 None => {}
             }
         }
@@ -1849,67 +1858,67 @@ pub fn l402_access_handler(
                 };
 
                 // 3. Resolve preimage: Redis cache → node lookup
-                let preimage_bytes: Vec<u8> =
-                    if let Some(cached) = get_cached_settled_preimage(&payment_hash) {
-                        debug!("💾 Using cached settled preimage");
-                        cached
-                    } else {
-                        // Use a lazily initialized static runtime
-                        static AUTODETECT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
-                        let rt = AUTODETECT_RUNTIME.get_or_init(|| {
-                            match tokio::runtime::Builder::new_multi_thread()
-                                .enable_all()
-                                .build()
-                            {
-                                Ok(rt) => rt,
-                                Err(e) => {
-                                    eprintln!("FATAL: failed to create autodetect runtime: {}", e);
-                                    std::process::abort();
-                                }
+                let preimage_bytes: Vec<u8> = if let Some(cached) =
+                    get_cached_settled_preimage(&payment_hash)
+                {
+                    debug!("💾 Using cached settled preimage");
+                    cached
+                } else {
+                    // Use a lazily initialized static runtime
+                    static AUTODETECT_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+                    let rt = AUTODETECT_RUNTIME.get_or_init(|| {
+                        match tokio::runtime::Builder::new_multi_thread()
+                            .enable_all()
+                            .build()
+                        {
+                            Ok(rt) => rt,
+                            Err(e) => {
+                                eprintln!("FATAL: failed to create autodetect runtime: {}", e);
+                                std::process::abort();
                             }
-                        });
+                        }
+                    });
 
-                        match payment_detector::PAYMENT_DETECTOR.get() {
-                            Some(detector) => {
-                                const AUTODETECT_LOOKUP_TIMEOUT: Duration =
-                                    Duration::from_secs(5);
-                                match rt.block_on(async {
-                                    tokio::time::timeout(
-                                        AUTODETECT_LOOKUP_TIMEOUT,
-                                        detector.lookup_settled_invoice(&payment_hash),
-                                    )
-                                    .await
-                                }) {
-                                    Ok(Ok(Some(p))) => {
-                                        // Cache for future requests
-                                        if let Err(e) = cache_settled_preimage(&payment_hash, &p) {
-                                            warn!("⚠️ Failed to cache settled preimage: {}", e);
-                                        }
-                                        p
+                    match payment_detector::PAYMENT_DETECTOR.get() {
+                        Some(detector) => {
+                            const AUTODETECT_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+                            match rt.block_on(async {
+                                tokio::time::timeout(
+                                    AUTODETECT_LOOKUP_TIMEOUT,
+                                    detector.lookup_settled_invoice(&payment_hash),
+                                )
+                                .await
+                            }) {
+                                Ok(Ok(Some(p))) => {
+                                    // Cache for future requests
+                                    if let Err(e) = cache_settled_preimage(&payment_hash, &p) {
+                                        warn!("⚠️ Failed to cache settled preimage: {}", e);
                                     }
-                                    Ok(Ok(None)) => {
-                                        info!("⏳ Invoice not yet settled — returning 402");
-                                        return 402;
-                                    }
-                                    Ok(Err(e)) => {
-                                        error!("❌ Node invoice lookup failed: {}", e);
-                                        return 500;
-                                    }
-                                    Err(_) => {
-                                        warn!(
+                                    p
+                                }
+                                Ok(Ok(None)) => {
+                                    info!("⏳ Invoice not yet settled — returning 402");
+                                    return 402;
+                                }
+                                Ok(Err(e)) => {
+                                    error!("❌ Node invoice lookup failed: {}", e);
+                                    return 500;
+                                }
+                                Err(_) => {
+                                    warn!(
                                             "Auto-detect invoice lookup timed out after {}s — returning 402",
                                             AUTODETECT_LOOKUP_TIMEOUT.as_secs()
                                         );
-                                        return 402;
-                                    }
+                                    return 402;
                                 }
                             }
-                            None => {
-                                error!("❌ PAYMENT_DETECTOR not initialised");
-                                return 500;
-                            }
                         }
-                    };
+                        None => {
+                            error!("❌ PAYMENT_DETECTOR not initialised");
+                            return 500;
+                        }
+                    }
+                };
 
                 // 4. Check replay (skipped when indefinite access is enabled).
                 if !indefinite_access && is_preimage_used(&preimage_bytes) {
@@ -2424,12 +2433,7 @@ fn handle_dry_run_passthrough(
         let header_result = rt.block_on(async {
             tokio::time::timeout(
                 DRY_RUN_CHALLENGE_TIMEOUT,
-                module.get_l402_header(
-                    caveats,
-                    final_amount,
-                    macaroon_timeout,
-                    final_lnurl_addr,
-                ),
+                module.get_l402_header(caveats, final_amount, macaroon_timeout, final_lnurl_addr),
             )
             .await
         });
@@ -2606,7 +2610,10 @@ pub unsafe extern "C" fn ngx_http_l402_indefinite_access_set(
         {
             conf.indefinite_access = false;
         } else {
-            error!("Invalid l402_indefinite_access value: '{}' (expected on/off)", val);
+            error!(
+                "Invalid l402_indefinite_access value: '{}' (expected on/off)",
+                val
+            );
             return b"l402_indefinite_access: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
         }
     }
@@ -2622,9 +2629,10 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
     // `ngx_http_conf_get_module_loc_conf` requires a valid module reference.
     // `ngx_http_core_module` is a static global defined by nginx core.
     unsafe {
-        let clcf: *mut ngx::ffi::ngx_http_core_loc_conf_t = NgxHttpCoreModule::location_conf_mut(&*cf)
-            .map(|r| r as *mut _)
-            .unwrap_or(std::ptr::null_mut());
+        let clcf: *mut ngx::ffi::ngx_http_core_loc_conf_t =
+            NgxHttpCoreModule::location_conf_mut(&*cf)
+                .map(|r| r as *mut _)
+                .unwrap_or(std::ptr::null_mut());
         if clcf.is_null() {
             return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
         }
@@ -2649,9 +2657,10 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_set(
 ) -> *mut c_char {
     // SAFETY: same guarantees as `ngx_http_l402_metrics_set` above.
     unsafe {
-        let clcf: *mut ngx::ffi::ngx_http_core_loc_conf_t = NgxHttpCoreModule::location_conf_mut(&*cf)
-            .map(|r| r as *mut _)
-            .unwrap_or(std::ptr::null_mut());
+        let clcf: *mut ngx::ffi::ngx_http_core_loc_conf_t =
+            NgxHttpCoreModule::location_conf_mut(&*cf)
+                .map(|r| r as *mut _)
+                .unwrap_or(std::ptr::null_mut());
         if clcf.is_null() {
             return b"l402_manifest: missing core loc conf\0".as_ptr() as *mut c_char;
         }
@@ -2786,7 +2795,11 @@ pub unsafe extern "C" fn ngx_http_l402_set(
         let conf = &mut *conf_ptr;
         let args = (*(*cf).args).elts as *mut ngx_str_t;
 
-        let val = (*args.add(1)).to_str().unwrap_or_default().trim().to_lowercase();
+        let val = (*args.add(1))
+            .to_str()
+            .unwrap_or_default()
+            .trim()
+            .to_lowercase();
 
         match val.as_str() {
             "on" | "true" | "1" | "yes" => {
@@ -2800,10 +2813,7 @@ pub unsafe extern "C" fn ngx_http_l402_set(
                     if let Ok(mut reg) = manifest_registry().lock() {
                         // Skip dup entries — `l402 on;` could appear more
                         // than once in pathological configs.
-                        if !reg
-                            .iter()
-                            .any(|r| r.path == path && r.conf.0 == conf_ptr)
-                        {
+                        if !reg.iter().any(|r| r.path == path && r.conf.0 == conf_ptr) {
                             reg.push(RouteRegistration {
                                 path,
                                 conf: ConfPtr(conf_ptr),
@@ -2928,7 +2938,8 @@ pub unsafe extern "C" fn ngx_http_l402_lnurl_set(
                 Ok(env_val) if !env_val.is_empty() => env_val,
                 _ => {
                     error!("❌ LNURL_ADDRESS environment variable is not set and no value provided in config");
-                    return b"LNURL_ADDRESS environment variable is not set\0".as_ptr() as *mut c_char;
+                    return b"LNURL_ADDRESS environment variable is not set\0".as_ptr()
+                        as *mut c_char;
                 }
             }
         };
@@ -2957,7 +2968,12 @@ fn get_client_ip(request: *mut ngx_http_request_t) -> String {
 
         // X-Real-IP: single IP set by a trusted reverse proxy
         if !r.headers_in.x_real_ip.is_null() {
-            let val = (*r.headers_in.x_real_ip).value.to_str().unwrap_or_default().trim().to_string();
+            let val = (*r.headers_in.x_real_ip)
+                .value
+                .to_str()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
             if !val.is_empty() {
                 return val;
             }
@@ -2965,7 +2981,10 @@ fn get_client_ip(request: *mut ngx_http_request_t) -> String {
 
         // X-Forwarded-For: "client, proxy1, proxy2" — leftmost is the origin
         if !r.headers_in.x_forwarded_for.is_null() {
-            let val_str = (*r.headers_in.x_forwarded_for).value.to_str().unwrap_or_default();
+            let val_str = (*r.headers_in.x_forwarded_for)
+                .value
+                .to_str()
+                .unwrap_or_default();
             if let Some(ip) = val_str.split(',').next() {
                 let ip = ip.trim();
                 if !ip.is_empty() {
@@ -3055,7 +3074,9 @@ pub unsafe extern "C" fn ngx_http_l402_invoice_rate_limit_set(
                 as *mut c_char;
         }
         let conf = &mut *(conf as *mut ModuleConfig);
-        let val = (*((*(*cf).args).elts as *mut ngx_str_t).add(1)).to_str().unwrap_or_default();
+        let val = (*((*(*cf).args).elts as *mut ngx_str_t).add(1))
+            .to_str()
+            .unwrap_or_default();
         match ngx_l402_core::parse_rate_limit(val) {
             Some((max_req, window_secs)) => {
                 conf.invoice_rate_limit = Some((max_req, window_secs));
@@ -3081,7 +3102,11 @@ pub unsafe extern "C" fn ngx_http_l402_auto_detect_payment_set(
     unsafe {
         let conf = &mut *(conf as *mut ModuleConfig);
         let args = (*(*cf).args).elts as *mut ngx_str_t;
-        let val = (*args.add(1)).to_str().unwrap_or_default().trim().to_lowercase();
+        let val = (*args.add(1))
+            .to_str()
+            .unwrap_or_default()
+            .trim()
+            .to_lowercase();
 
         match val.as_str() {
             "on" | "true" | "1" | "yes" => {
@@ -3093,7 +3118,10 @@ pub unsafe extern "C" fn ngx_http_l402_auto_detect_payment_set(
                 info!("⚙️ Disabled L402 auto-detect payment for this location");
             }
             _ => {
-                error!("❌ Invalid auto_detect_payment configuration value: {}", val);
+                error!(
+                    "❌ Invalid auto_detect_payment configuration value: {}",
+                    val
+                );
                 return std::ptr::null_mut();
             }
         }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -210,4 +210,3 @@ fn route_block(r: &RouteSnapshot) -> Value {
 
     Value::Object(block)
 }
-

--- a/src/payment_detector.rs
+++ b/src/payment_detector.rs
@@ -19,7 +19,6 @@ use std::sync::OnceLock;
 use tonic;
 use tonic_openssl_lnd::lnrpc;
 
-
 /// The configured detector (one instance for the lifetime of the worker).
 pub static PAYMENT_DETECTOR: OnceLock<PaymentDetector> = OnceLock::new();
 
@@ -54,8 +53,7 @@ impl PaymentDetector {
 
 /// Called once from `init_module`.  Reads env vars and builds the detector.
 pub fn init_payment_detector() {
-    let ln_client_type =
-        std::env::var("LN_CLIENT_TYPE").unwrap_or_else(|_| "LNURL".to_string());
+    let ln_client_type = std::env::var("LN_CLIENT_TYPE").unwrap_or_else(|_| "LNURL".to_string());
 
     let detector = match ln_client_type.as_str() {
         "LND" => {
@@ -66,16 +64,13 @@ pub fn init_payment_detector() {
                     reason: "LNC mailbox does not expose LookupInvoice".into(),
                 }
             } else {
-                let address = std::env::var("LND_ADDRESS")
-                    .unwrap_or_else(|_| "localhost:10009".to_string());
+                let address =
+                    std::env::var("LND_ADDRESS").unwrap_or_else(|_| "localhost:10009".to_string());
                 let macaroon_file = std::env::var("MACAROON_FILE_PATH")
                     .unwrap_or_else(|_| "admin.macaroon".to_string());
-                let cert_file = std::env::var("CERT_FILE_PATH")
-                    .unwrap_or_else(|_| "tls.cert".to_string());
-                info!(
-                    "✅ LND payment detector initialised ({})",
-                    address
-                );
+                let cert_file =
+                    std::env::var("CERT_FILE_PATH").unwrap_or_else(|_| "tls.cert".to_string());
+                info!("✅ LND payment detector initialised ({})", address);
                 PaymentDetector::Lnd(LndDetector {
                     address,
                     macaroon_file,
@@ -117,7 +112,10 @@ pub fn init_payment_detector() {
                 ln_client_type
             );
             PaymentDetector::Unsupported {
-                reason: format!("{} cannot query remote wallet invoice state", ln_client_type),
+                reason: format!(
+                    "{} cannot query remote wallet invoice state",
+                    ln_client_type
+                ),
             }
         }
     };
@@ -127,7 +125,6 @@ pub fn init_payment_detector() {
     }
 }
 
-
 pub struct LndDetector {
     pub address: String,
     pub macaroon_file: String,
@@ -136,7 +133,6 @@ pub struct LndDetector {
 
 impl LndDetector {
     pub async fn lookup(&self, payment_hash: &[u8]) -> Result<Option<Vec<u8>>, String> {
-
         let parts: Vec<&str> = self.address.split(':').collect();
         if parts.len() != 2 {
             return Err(format!("Invalid LND_ADDRESS: {}", self.address));
@@ -146,10 +142,14 @@ impl LndDetector {
             .parse()
             .map_err(|_| "Invalid LND port".to_string())?;
 
-        let mut client =
-            tonic_openssl_lnd::connect(host, port, self.cert_file.clone(), self.macaroon_file.clone())
-                .await
-                .map_err(|e| format!("LND connection failed: {}", e))?;
+        let mut client = tonic_openssl_lnd::connect(
+            host,
+            port,
+            self.cert_file.clone(),
+            self.macaroon_file.clone(),
+        )
+        .await
+        .map_err(|e| format!("LND connection failed: {}", e))?;
 
         let request = lnrpc::PaymentHash {
             r_hash: payment_hash.to_vec(),
@@ -187,7 +187,6 @@ impl LndDetector {
     }
 }
 
-
 pub struct ClnDetector {
     pub rpc_path: String,
 }
@@ -223,7 +222,10 @@ impl ClnDetector {
         let invoice = match resp.invoices.into_iter().next() {
             Some(inv) => inv,
             None => {
-                warn!("⚠️  CLN: no invoice found for payment_hash {}", &payment_hash_hex[..16]);
+                warn!(
+                    "⚠️  CLN: no invoice found for payment_hash {}",
+                    &payment_hash_hex[..16]
+                );
                 return Ok(None);
             }
         };
@@ -238,12 +240,14 @@ impl ClnDetector {
                 None => Err("CLN invoice settled but preimage missing".into()),
             }
         } else {
-            debug!("⏳ CLN invoice not yet settled (status={:?})", invoice.status);
+            debug!(
+                "⏳ CLN invoice not yet settled (status={:?})",
+                invoice.status
+            );
             Ok(None)
         }
     }
 }
-
 
 pub struct EclairDetector {
     pub api_url: String,
@@ -265,12 +269,18 @@ impl EclairDetector {
             .map_err(|e| format!("Eclair HTTP error: {}", e))?;
 
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            warn!("⚠️  Eclair: invoice not found for payment_hash {}", &payment_hash_hex[..16]);
+            warn!(
+                "⚠️  Eclair: invoice not found for payment_hash {}",
+                &payment_hash_hex[..16]
+            );
             return Ok(None);
         }
 
         if !resp.status().is_success() {
-            return Err(format!("Eclair /getreceivedinfo returned HTTP {}", resp.status()));
+            return Err(format!(
+                "Eclair /getreceivedinfo returned HTTP {}",
+                resp.status()
+            ));
         }
 
         let body: serde_json::Value = resp

--- a/src/payment_page.rs
+++ b/src/payment_page.rs
@@ -50,8 +50,14 @@ pub fn render_payment_page(
     let amount_sats = amount_msat / 1000;
     let invoice_short = if invoice.chars().count() > 40 {
         let head: String = invoice.chars().take(20).collect();
-        let tail: String = invoice.chars().rev().take(10).collect::<String>()
-            .chars().rev().collect();
+        let tail: String = invoice
+            .chars()
+            .rev()
+            .take(10)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
         html_escape(&format!("{}\u{2026}{}", head, tail))
     } else {
         html_escape(invoice)
@@ -376,8 +382,16 @@ document.getElementById('preimage-section').classList.remove('hidden')\">Enter p
         auto_detect_section = auto_detect_section,
         preimage_hidden_class = preimage_hidden_class,
         cashu_tab_html = cashu_tab_html,
-        invoice_json = serde_json::to_string(invoice).unwrap_or_else(|_| "\"\"".to_string()).replace('<', "\\u003c").replace('>', "\\u003e").replace('&', "\\u0026"),
-        macaroon_json = serde_json::to_string(macaroon_b64).unwrap_or_else(|_| "\"\"".to_string()).replace('<', "\\u003c").replace('>', "\\u003e").replace('&', "\\u0026"),
+        invoice_json = serde_json::to_string(invoice)
+            .unwrap_or_else(|_| "\"\"".to_string())
+            .replace('<', "\\u003c")
+            .replace('>', "\\u003e")
+            .replace('&', "\\u0026"),
+        macaroon_json = serde_json::to_string(macaroon_b64)
+            .unwrap_or_else(|_| "\"\"".to_string())
+            .replace('<', "\\u003c")
+            .replace('>', "\\u003e")
+            .replace('&', "\\u0026"),
         auto_detect_js = auto_detect_js,
     )
 }


### PR DESCRIPTION
First of two PRs for #145. I noted the split in a comment there. This one adds a lint workflow that runs `cargo fmt --check` on every PR and push to main, and runs `cargo fmt` over the codebase so the gate passes. The formatting diff is big but purely mechanical: 8 files, line-wrapping only, no logic changes. I'll send the clippy `-D warnings` gate as a follow-up.

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402/prs/nevent1qy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqg8l5p62tj6uhyl9dc29muygjxn8j4623t97mvtr64e8jyw07xmr0yn8qvzj)

Part of #145