### PR TITLE
ci: add clippy -D warnings lint gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,14 +42,15 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       # nginx-sys builds bindings from the nginx source tree, so clippy needs
-      # it configured first. --with-compat matches the Dockerfile build; the
-      # realip module is required because src/lib.rs reads x_real_ip, which is
-      # guarded by NGX_HTTP_REALIP.
+      # it configured first. --with-compat matches the Dockerfile build and
+      # covers the x_real_ip field that src/lib.rs reads (NGX_HTTP_REALIP is
+      # defined by --with-compat; the two --without flags only keep runner
+      # deps minimal and don't affect the binding surface for this code).
       - name: Download and configure nginx source
         run: |
           curl -fsSL https://nginx.org/download/nginx-1.28.0.tar.gz | tar xz
           cd nginx-1.28.0
-          ./configure --with-compat --with-http_realip_module \
+          ./configure --with-compat \
             --without-http_rewrite_module --without-http_gzip_module
 
       - name: Run clippy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,37 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      # tonic's build script shells out to protoc; not present on clean runners.
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      # nginx-sys builds bindings from the nginx source tree, so clippy needs
+      # it configured first. --with-compat matches the Dockerfile build; the
+      # realip module is required because src/lib.rs reads x_real_ip, which is
+      # guarded by NGX_HTTP_REALIP.
+      - name: Download and configure nginx source
+        run: |
+          curl -fsSL https://nginx.org/download/nginx-1.28.0.tar.gz | tar xz
+          cd nginx-1.28.0
+          ./configure --with-compat --with-http_realip_module \
+            --without-http_rewrite_module --without-http_gzip_module
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+        env:
+          NGINX_SOURCE_DIR: ${{ github.workspace }}/nginx-1.28.0

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -1,8 +1,6 @@
 use crate::cashu_redemption_logger;
 use crate::REDIS_POOL;
-use cdk;
 use cdk::mint_url::MintUrl;
-use hex;
 use l402_middleware::lnclient;
 use l402_middleware::lndrpc::lnrpc;
 use log::{debug, error, info, warn};
@@ -17,7 +15,7 @@ use url::Url;
 
 // Thread-local storage to track processed tokens
 thread_local! {
-    static PROCESSED_TOKENS: RefCell<Option<HashSet<String>>> = RefCell::new(None);
+    static PROCESSED_TOKENS: RefCell<Option<HashSet<String>>> = const { RefCell::new(None) };
 }
 
 const MSAT_PER_SAT: u64 = 1000;
@@ -377,7 +375,7 @@ fn verify_proof_dleq_offline(
 
 /// Check if multi-tenant LNURL mode is enabled (LN_CLIENT_TYPE=LNURL)
 pub fn is_multi_tenant_enabled() -> bool {
-    LN_CLIENT_TYPE.get().map_or(false, |t| t == "LNURL")
+    LN_CLIENT_TYPE.get().is_some_and(|t| t == "LNURL")
 }
 
 /// Initialize the LN client type for cashu redemption (called from lib.rs).
@@ -710,7 +708,7 @@ fn group_proofs_by_lnurl(
             continue;
         }
 
-        grouped.entry(lnurl).or_insert_with(Vec::new).push(proof);
+        grouped.entry(lnurl).or_default().push(proof);
     }
 
     Ok(grouped)
@@ -998,7 +996,7 @@ pub async fn verify_cashu_token_p2pk(
         tokens
             .borrow()
             .as_ref()
-            .map_or(false, |set| set.contains(token))
+            .is_some_and(|set| set.contains(token))
     });
 
     if token_seen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use env_logger;
-use hex;
 use l402_middleware::lndrpc::lnrpc;
 use l402_middleware::middleware::L402Middleware;
 use l402_middleware::{bolt12, cln, eclair, l402, lnclient, lnd, lnurl, macaroon_util, nwc, utils};
@@ -160,6 +158,9 @@ fn get_cashu_token_ttl() -> u64 {
 
 // Cache for LNURL clients - lazy initialization on first use per address
 // Uses RwLock instead of Mutex since reads (cache hits) vastly outnumber writes (new client creation)
+// The nested type mirrors the cached value's shape; extracting a `type`
+// alias for it is intentionally deferred.
+#[allow(clippy::type_complexity)]
 static LNURL_CLIENT_CACHE: OnceLock<
     tokio::sync::RwLock<HashMap<String, Arc<tokio::sync::Mutex<dyn lnclient::LNClient + Send>>>>,
 > = OnceLock::new();
@@ -481,7 +482,7 @@ pub fn cache_settled_preimage(payment_hash: &[u8], preimage: &[u8]) -> Result<()
 
 /// Parse the macaroon from an L402 authorization string and return
 /// the raw 32-byte payment hash embedded in its identifier.
-
+///
 /// Accepts both formats:
 ///   - `L402 <macaroon_b64>:<preimage_hex>`  (classic)
 ///   - `L402 <macaroon_b64>`                 (auto-detect)
@@ -1072,7 +1073,7 @@ unsafe extern "C" fn metrics_shm_init(zone: *mut ngx_shm_zone_t, data: *mut c_vo
         error!("⚠️ l402_metrics: slab allocation failed; metrics will be per-worker");
         return NGX_ERROR as ngx_int_t;
     }
-    if (raw as usize) % metrics::BLOCK_ALIGN != 0 {
+    if !(raw as usize).is_multiple_of(metrics::BLOCK_ALIGN) {
         // Should not happen (slab slots are at least word-aligned), but writing
         // an AtomicU64 array through a misaligned pointer would be UB.
         error!("⚠️ l402_metrics: slab allocation misaligned; metrics will be per-worker");
@@ -1367,7 +1368,7 @@ unsafe fn send_html_response(r: *mut ngx_http_request_t, status: u16, body: Stri
         || send_status.0 > NGX_OK as ngx_int_t
         || req.header_only()
     {
-        return send_status.0 as isize;
+        return send_status.0;
     }
 
     let rc = unsafe { req.output_filter(&mut *chain).0 };
@@ -1398,10 +1399,11 @@ thread_local! {
         const { std::cell::Cell::new(None) };
 }
 
-// SAFETY: This function is an Nginx access-phase handler registered via
-// `postconfiguration`. Nginx guarantees that `request`, `request->connection`,
-// `request->connection->log`, and `request->loc_conf` are valid, non-null
-// pointers for the handler's lifetime.
+/// # Safety
+/// This function is an Nginx access-phase handler registered via
+/// `postconfiguration`. Nginx guarantees that `request`, `request->connection`,
+/// `request->connection->log`, and `request->loc_conf` are valid, non-null
+/// pointers for the handler's lifetime.
 pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_request_t) -> isize {
     let handler_start = Instant::now();
 
@@ -1448,8 +1450,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let loc_conf = r.loc_conf;
         // SAFETY: The config slot is allocated by `create_loc_conf` and merged
         // by Nginx before the access phase runs.
-        let conf =
-            &*((*loc_conf.offset(ngx_http_l402_module.ctx_index as isize)) as *const ModuleConfig);
+        let conf = &*((*loc_conf.add(ngx_http_l402_module.ctx_index)) as *const ModuleConfig);
 
         if !conf.enable {
             ngx_log_error!(NGX_LOG_INFO, log_ref, "L402 is disabled for this location");
@@ -1781,6 +1782,9 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     result
 }
 
+// Thin entry point the C wrapper forwards to; packing its 8 parameters into
+// a struct is intentionally deferred to keep the FFI call site simple.
+#[allow(clippy::too_many_arguments)]
 pub fn l402_access_handler(
     auth_header: Option<String>,
     uri: String,
@@ -2087,6 +2091,12 @@ pub fn l402_access_handler(
     402
 }
 
+/// Nginx module init callback, invoked once at master-process startup.
+///
+/// # Safety
+/// `cycle` must be the valid cycle pointer supplied by Nginx when it invokes
+/// the module's init callback. It is null-checked defensively before any
+/// dereference; `cycle->log` is guaranteed valid by Nginx at this stage.
 pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     if cycle.is_null() {
         return -1;
@@ -2514,6 +2524,10 @@ fn dry_run_runtime() -> &'static Runtime {
 /// exposition format at the configured location (e.g. `/metrics`).
 ///
 /// Only `GET` and `HEAD` are accepted; anything else returns `405`.
+///
+/// # Safety
+/// `r` must be the non-null, valid request pointer Nginx passes to
+/// content-phase handlers; it stays valid for the handler's lifetime.
 pub unsafe extern "C" fn l402_metrics_content_handler(r: *mut ngx_http_request_t) -> ngx_int_t {
     // SAFETY: nginx passes a non-null, valid request pointer to content
     // phase handlers for the lifetime of the call.
@@ -2567,6 +2581,13 @@ pub unsafe extern "C" fn l402_metrics_content_handler(r: *mut ngx_http_request_t
     unsafe { req.output_filter(&mut *chain).0 }
 }
 
+/// Directive handler for `l402_dry_run on|off;`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2587,12 +2608,19 @@ pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
             conf.dry_run = Some(false);
         } else {
             error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
-            return b"l402_dry_run: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
+            return c"l402_dry_run: expected 'on' or 'off'".as_ptr() as *mut c_char;
         }
     }
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_indefinite_access on|off;`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_indefinite_access_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2624,12 +2652,19 @@ pub unsafe extern "C" fn ngx_http_l402_indefinite_access_set(
                 "Invalid l402_indefinite_access value: '{}' (expected on/off)",
                 val
             );
-            return b"l402_indefinite_access: expected 'on' or 'off'\0".as_ptr() as *mut c_char;
+            return c"l402_indefinite_access: expected 'on' or 'off'".as_ptr() as *mut c_char;
         }
     }
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_metrics;` (no args). Registers the metrics
+/// content handler for the location.
+///
+/// # Safety
+/// `cf` is the valid config pointer Nginx passes to directive-parsing
+/// callbacks; the core location config obtained through it is null-checked
+/// before its handler slot is written. The `conf` argument is unused.
 pub unsafe extern "C" fn ngx_http_l402_metrics_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2644,15 +2679,15 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
                 .map(|r| r as *mut _)
                 .unwrap_or(std::ptr::null_mut());
         if clcf.is_null() {
-            return b"l402_metrics: missing core loc conf\0".as_ptr() as *mut c_char;
+            return c"l402_metrics: missing core loc conf".as_ptr() as *mut c_char;
         }
         // Refuse to silently clobber a content handler registered by another
         // directive (e.g. `proxy_pass`, `return`, `alias` + `try_files`, etc.).
         // Fail fast at `nginx -t` rather than surprise operators at runtime.
         if (*clcf).handler.is_some() {
             error!("l402_metrics: another content handler is already registered for this location");
-            return b"l402_metrics: conflicts with another content handler in this location\0"
-                .as_ptr() as *mut c_char;
+            return c"l402_metrics: conflicts with another content handler in this location".as_ptr()
+                as *mut c_char;
         }
         (*clcf).handler = Some(l402_metrics_content_handler);
     }
@@ -2660,6 +2695,13 @@ pub unsafe extern "C" fn ngx_http_l402_metrics_set(
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_manifest;` (no args). Registers the manifest
+/// content handler for the location.
+///
+/// # Safety
+/// Same guarantees as `ngx_http_l402_metrics_set`: `cf` is the valid config
+/// pointer Nginx passes to directive-parsing callbacks, and the core
+/// location config obtained through it is null-checked before use.
 pub unsafe extern "C" fn ngx_http_l402_manifest_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2672,13 +2714,13 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_set(
                 .map(|r| r as *mut _)
                 .unwrap_or(std::ptr::null_mut());
         if clcf.is_null() {
-            return b"l402_manifest: missing core loc conf\0".as_ptr() as *mut c_char;
+            return c"l402_manifest: missing core loc conf".as_ptr() as *mut c_char;
         }
         if (*clcf).handler.is_some() {
             error!(
                 "l402_manifest: another content handler is already registered for this location"
             );
-            return b"l402_manifest: conflicts with another content handler in this location\0"
+            return c"l402_manifest: conflicts with another content handler in this location"
                 .as_ptr() as *mut c_char;
         }
         (*clcf).handler = Some(l402_manifest_content_handler);
@@ -2687,6 +2729,12 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_set(
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_manifest_hide;` (no args). Excludes the
+/// location from the `.well-known/l402-services` capability manifest.
+///
+/// # Safety
+/// `conf` must point to this location's `ModuleConfig`, which Nginx
+/// guarantees is valid and non-null during directive-parsing callbacks.
 pub unsafe extern "C" fn ngx_http_l402_manifest_hide_set(
     _cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2708,6 +2756,10 @@ pub unsafe extern "C" fn ngx_http_l402_manifest_hide_set(
 /// Only `GET` and `HEAD` are accepted; anything else returns `405`. The
 /// manifest is rebuilt on every request — cheap because the registry is
 /// in-process and small (one entry per l402-protected location).
+///
+/// # Safety
+/// `r` must be the non-null, valid request pointer Nginx passes to
+/// content-phase handlers; it stays valid for the handler's lifetime.
 pub unsafe extern "C" fn l402_manifest_content_handler(r: *mut ngx_http_request_t) -> ngx_int_t {
     let r_ref = unsafe { &mut *r };
 
@@ -2792,6 +2844,14 @@ fn collect_route_snapshots() -> Vec<manifest::RouteSnapshot> {
         .collect()
 }
 
+/// Directive handler for `l402 on|off;`. Enables L402 for the location and
+/// registers it in the manifest route registry.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2863,6 +2923,13 @@ unsafe fn location_name_str(cf: *mut ngx_conf_t) -> Option<String> {
     Some(String::from_utf8_lossy(slice).into_owned())
 }
 
+/// Directive handler for `l402_amount_msat_default <msat>;`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_amount_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2892,6 +2959,13 @@ pub unsafe extern "C" fn ngx_http_l402_amount_set(
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_macaroon_timeout <seconds>;`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_timeout_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2926,6 +3000,14 @@ pub unsafe extern "C" fn ngx_http_l402_timeout_set(
     std::ptr::null_mut()
 }
 
+/// Directive handler for `l402_lnurl_addr <address>;`. Falls back to the
+/// `LNURL_ADDRESS` env var when the config value is empty.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_lnurl_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -2948,7 +3030,7 @@ pub unsafe extern "C" fn ngx_http_l402_lnurl_set(
                 Ok(env_val) if !env_val.is_empty() => env_val,
                 _ => {
                     error!("❌ LNURL_ADDRESS environment variable is not set and no value provided in config");
-                    return b"LNURL_ADDRESS environment variable is not set\0".as_ptr()
+                    return c"LNURL_ADDRESS environment variable is not set".as_ptr()
                         as *mut c_char;
                 }
             }
@@ -3069,6 +3151,12 @@ fn check_invoice_rate_limit(ip: &str, path: &str, max_requests: u32, window_secs
 ///   `l402_invoice_rate_limit 10r/h;`  - 10 per hour
 ///   `l402_invoice_rate_limit 2r/s;`   - 2 per second
 ///   `l402_invoice_rate_limit 5;`      - 5 per minute (shorthand)
+///
+/// # Safety
+/// `cf` and `conf` are the pointers Nginx passes to directive-parsing
+/// callbacks; both are null-checked defensively before use. When valid,
+/// `conf` points to this location's `ModuleConfig`, and `(*cf).args` holds
+/// exactly one argument because the directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_invoice_rate_limit_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -3080,8 +3168,7 @@ pub unsafe extern "C" fn ngx_http_l402_invoice_rate_limit_set(
     // single argument, guaranteed present by NGX_CONF_TAKE1.
     unsafe {
         if cf.is_null() || conf.is_null() {
-            return b"l402_invoice_rate_limit: null configuration pointer\0".as_ptr()
-                as *mut c_char;
+            return c"l402_invoice_rate_limit: null configuration pointer".as_ptr() as *mut c_char;
         }
         let conf = &mut *(conf as *mut ModuleConfig);
         let val = (*((*(*cf).args).elts as *mut ngx_str_t).add(1))
@@ -3097,13 +3184,20 @@ pub unsafe extern "C" fn ngx_http_l402_invoice_rate_limit_set(
             }
             None => {
                 error!("Invalid l402_invoice_rate_limit value: '{}'", val);
-                return b"l402_invoice_rate_limit: expected e.g. '5r/m', '10r/h', '2r/s', or '5'\0"
+                return c"l402_invoice_rate_limit: expected e.g. '5r/m', '10r/h', '2r/s', or '5'"
                     .as_ptr() as *mut c_char;
             }
         }
     }
     std::ptr::null_mut()
 }
+/// Directive handler for `l402_auto_detect_payment on|off;`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
 pub unsafe extern "C" fn ngx_http_l402_auto_detect_payment_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,

--- a/src/payment_detector.rs
+++ b/src/payment_detector.rs
@@ -16,7 +16,6 @@
 use log::{debug, error, info, warn};
 use reqwest::Client as HttpClient;
 use std::sync::OnceLock;
-use tonic;
 use tonic_openssl_lnd::lnrpc;
 
 /// The configured detector (one instance for the lifetime of the worker).
@@ -106,7 +105,7 @@ pub fn init_payment_detector() {
                 reason: "NWC lookup_invoice is not universally supported".into(),
             }
         }
-        "LNURL" | _ => {
+        _ => {
             warn!(
                 "⚠️  {} backend does not support server-side invoice lookup; disabling auto-detect",
                 ln_client_type


### PR DESCRIPTION
Second of two PRs for #145. The first (fmt gate) just merged in #152.

This adds a clippy job to the lint workflow (`cargo clippy --all-targets -- -D warnings`) and fixes the 43 existing warnings so the gate passes. Most of it was mechanical: `# Safety` doc sections on 15 unsafe fns (written to match the unsafe-code conventions in CONTRIBUTING.md), c-string literals instead of manual `\0` construction, and `cargo clippy --fix` suggestions.

Two judgment calls worth a look. I put allows on `clippy::too_many_arguments` for `l402_access_handler` and `clippy::type_complexity` for the LNURL client cache, since fixing them properly means a function signature change and a type-alias refactor respectively. Happy to do those refactors as a follow-up if you'd rather see them clean.

One CI quirk: the clippy job configures nginx with `--with-compat --with-http_realip_module`. Without realip, `ngx_http_headers_in_t` doesn't have the `x_real_ip` field, and `src/lib.rs` reads it, so the build fails. The workflow has a comment explaining this.

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/relay.ngit.dev/ngx-l402/prs/nevent1qy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqg9eq6c7snuxk6gjmztzca90hz8szhv0ajvw8lk5n5z94e94xck6augsw33j)

Closes #145