### PR TITLE
docs: fix stale nginx versions, docker tag, and GHCR namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For local contributor setup on macOS (Docker nginx recommended), see `docs/macos
 
 > Requires **NGINX 1.28.0** or later.
 >
-> Pre-built binaries are provided for **NGINX 1.28.0** only. For other versions, build from source:
+> Pre-built binaries are provided for NGINX **1.28.0, 1.28.3, 1.29.8, 1.30.3, and 1.31.2** (see [Releases](https://github.com/ngx-l402/ngx-l402/releases)). For other versions, build from source:
 > ```
 > docker build --build-arg NGX_VERSION=<your-version> -t ngx_l402 .
 > ```

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -178,7 +178,7 @@ docker stop l402-nginx
 ## Specific Versions
 
 ```bash
-docker pull ghcr.io/ngx-l402/ngx-l402:v1.2.8
+docker pull ghcr.io/ngx-l402/ngx-l402:1.2.6
 
 # Releases up to v1.2.7 were published under the previous namespace:
 docker pull ghcr.io/dhananjaypurohit/ngx_l402:v1.2.5

--- a/examples/demo-gateway/docker-compose.yml
+++ b/examples/demo-gateway/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: ghcr.io/dhananjaypurohit/ngx_l402:latest
+    image: ghcr.io/ngx-l402/ngx-l402:latest
     container_name: l402-demo-gateway
     depends_on:
       - redis

--- a/examples/llm-api-paywall/docker-compose.yml
+++ b/examples/llm-api-paywall/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - redis:/data
 
   gateway:
-    image: ghcr.io/dhananjaypurohit/ngx_l402:latest
+    image: ghcr.io/ngx-l402/ngx-l402:latest
     container_name: l402-gateway
     depends_on:
       - ollama


### PR DESCRIPTION
Closes #159

Three stale references, checked against the v1.2.7 release assets and the live GHCR tag lists:

1. `README.md:39` said prebuilt binaries cover nginx 1.28.0 only. The v1.2.7 release ships five tarballs, matching the compat matrix in `.github/workflows/nginx-compat.yml` (1.28.0, 1.28.3, 1.29.8, 1.30.3, 1.31.2). The README now lists them and links to the releases page.
2. `docs/install-docker.md:181` had `docker pull ghcr.io/ngx-l402/ngx-l402:v1.2.8`. That tag doesn't exist on either namespace, and tags on the new namespace have no `v` prefix, so the command fails as written. I changed it to `1.2.6`, the newest tag published there.
3. The demo-gateway and llm-api-paywall compose files still pulled from `ghcr.io/dhananjaypurohit/ngx_l402`. Both now use `ghcr.io/ngx-l402/ngx-l402:latest`, same as the README quickstart and paywalled-blossom.

One gap this PR can't fix: `ghcr.io/ngx-l402/ngx-l402` tops out at `1.2.6` right now. `1.2.7` only ever got published to the old namespace, which the install docs already note. So the examples will track `latest` at 1.2.6 until the next release publishes to the new namespace. Tagging `1.2.7` there too would close the gap.

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402/prs/nevent1qqs2nrdcdx7t6nrqv3pqnxfks3lnndalnffsmr4arlevwrn6cure3dgpz3mhxue69uhhyetvv9ujumn8d96zuer9wcvzeant)
