### PR TITLE
ci: pin the nostr-rs-relay image to 0.10.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   # Local Nostr relay for the NWC tests.
   nostr-relay:
-    image: scsibug/nostr-rs-relay:latest
+    image: scsibug/nostr-rs-relay:0.10.0
     container_name: nostr-relay
     ports:
       - "7000:8080"


### PR DESCRIPTION
The Nostr relay used by the NWC tests was the only image in `docker-compose.yml` floating on `latest`. Pin it to `0.10.0`, the current upstream release. Its digest matches today's `latest` (`sha256:48d54c2d...`), so CI runs the same bytes, just frozen.

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402/prs/nevent1qqsfgad5nh9d7x968z7u4jq26wg8nfdaf0wywa6f099dm8hr3g859ugpz3mhxue69uhhyetvv9ujumn8d96zuer9wcc9n3xm)
